### PR TITLE
Fix: use theme config over system default

### DIFF
--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -223,7 +223,8 @@ import Typesense from 'typesense';
         }
 
         updateTheme() {
-            const isDarkMode = this.config.theme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const preferDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const isDarkMode = this.config.theme === 'light' ? false : (this.config.theme === 'dark' || preferDark);
             this.modal.classList.toggle(`${CSS_PREFIX}-dark`, isDarkMode);
         }
 

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -223,7 +223,7 @@ import Typesense from 'typesense';
         }
 
         updateTheme() {
-            const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const isDarkMode = this.config.theme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches;
             this.modal.classList.toggle(`${CSS_PREFIX}-dark`, isDarkMode);
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dark mode now follows your chosen theme: explicitly off when set to Light, on when set to Dark, and otherwise follows your system preference.
  * Modal appearance now consistently matches the computed light/dark mode to avoid mismatched styling across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->