### PR TITLE
feat: emit opt-in search analytics events (close #13)

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -88,6 +88,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `transformToRelativeUrls` | `Boolean` | No | `false` | Convert result URLs to relative paths (useful for proxy domains or custom domain setups) |
 | `locale` | `String` | No | `'en'` | Locale identifier for i18n translations |
 | `i18n` | `Object` | No | `{}` | Translation overrides for UI strings (see [Internationalization](#internationalization-i18n)) |
+| `analytics` | `Object` | No | — | Opt-in search analytics — emit query, click, and zero-result events to your own endpoint (see [Analytics](#analytics)) |
 
 ### Search Fields Configuration
 
@@ -143,7 +144,7 @@ Use `typesenseSearchParams` to override any of the default Typesense search para
 | `drop_tokens_threshold` | `0` | Token drop threshold for relaxing multi-word queries |
 | `enable_nested_fields` | `true` | Enable searching in nested fields (e.g., `tags.name`) |
 | `highlight_affix_num_tokens` | `30` | Number of surrounding tokens shown in highlighted excerpts |
-| `include_fields` | `'title,url,excerpt,plaintext,published_at,tags'` | Fields returned in search results |
+| `include_fields` | `'id,title,url,excerpt,plaintext,published_at,tags'` | Fields returned in search results |
 
 **Sorting examples:**
 
@@ -193,6 +194,57 @@ window.__MP_SEARCH_CONFIG__ = {
 ```
 
 > **Note:** If you provide a custom `query_by` without a matching `query_by_weights`, the default weights are automatically removed to avoid mismatches. If you override `query_by`, you should also provide `query_by_weights`.
+
+## Analytics
+
+Search analytics are **opt-in and disabled by default**. With no `analytics` configuration, the widget makes no network requests beyond Typesense.
+
+When you provide an `analytics.endpoint`, the widget emits lightweight events to that endpoint so you can learn what readers search for, what they click, and which queries return nothing. The widget only *emits* events — it does not ship a backend. You point it at an endpoint you operate (or any compatible analytics service).
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    analytics: {
+        endpoint: 'https://your-endpoint.example.com/collect', // required to enable
+        siteId: 'my-site',           // optional: identifies this site to your backend
+        token: 'public-write-token'  // optional: included with each event for auth
+    }
+};
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `endpoint` | `String` | Yes | URL that receives events via HTTP POST. Its presence is what enables analytics. |
+| `siteId` | `String` | No | Opaque identifier sent with every event, so a single endpoint can serve multiple sites. |
+| `token` | `String` | No | Write token included in the event body, for endpoints that authenticate writes. |
+
+### Events
+
+Each event is POSTed as a JSON body. Three event types are emitted:
+
+| Event | When | Payload |
+|-------|------|---------|
+| `search` | A settled query returns results | `{ type: 'search', q, resultCount, siteId, token, ts }` |
+| `zero_result` | A settled query returns no results | `{ type: 'zero_result', q, resultCount: 0, siteId, token, ts }` |
+| `click` | A reader opens a result (by click or keyboard) | `{ type: 'click', q, resultId, position, siteId, token, ts }` |
+
+- `q` — the search query string
+- `resultCount` — total number of matches
+- `resultId` — the Typesense document `id` of the clicked result
+- `position` — zero-based index of the clicked result in the list
+- `ts` — client timestamp in milliseconds
+
+A `search` event is emitted once per settled query (typing character-by-character produces a single event for the final query, not one per keystroke). Reopening the search and repeating a query counts as a new search.
+
+### Transport and reliability
+
+Events are sent with [`navigator.sendBeacon()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon), falling back to `fetch(..., { keepalive: true })` where `sendBeacon` is unavailable. This means `click` events are delivered reliably even though clicking a result navigates away from the page.
+
+Analytics are **fail-silent**: any network error, or a non-success response from your endpoint, is swallowed and never affects the search experience.
+
+### Privacy
+
+The widget collects **no personal data**. It sets no cookies, stores no client-side tracking identifier, and performs no fingerprinting. Events contain only the query text, a clicked result's id and position, and a timestamp. Anything further (IP, geography, aggregation, retention) is entirely a matter for the endpoint you operate.
 
 ## Usage
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -244,7 +244,7 @@ Analytics are **fail-silent**: any network error, or a non-success response from
 
 ### Privacy
 
-The widget collects **no personal data**. It sets no cookies, stores no client-side tracking identifier, and performs no fingerprinting. Events contain only the query text, a clicked result's id and position, and a timestamp. Anything further (IP, geography, aggregation, retention) is entirely a matter for the endpoint you operate.
+The widget uses **no persistent client-side tracking**: it sets no cookies, stores no tracking identifier, and performs no fingerprinting. Each event contains only the search query, a clicked result's id and position, and a timestamp. Note that the query text is user-provided input and may itself contain personal data depending on what a reader types. Anything further — associating events with a person, IP, geography, aggregation, or retention — is entirely a matter for the endpoint you operate.
 
 ## Usage
 

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -145,6 +145,19 @@ import Typesense from 'typesense';
             return this.i18n[key] || this.defaultI18n[key] || key;
         }
 
+        // Escape a value for safe interpolation into an HTML attribute. Used
+        // for indexed values (e.g. a document id) that are written into the
+        // results markup via innerHTML and would otherwise allow a crafted
+        // value to break out of its attribute.
+        escapeHtmlAttr(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         // Convert absolute URL to relative path
         toRelativeUrl(url) {
             if (!url) return '#';
@@ -658,7 +671,7 @@ import Typesense from 'typesense';
                     return `
                         <a href="${resultUrl}"
                             class="${CSS_PREFIX}-result-link"
-                            data-result-id="${hit.document.id || ''}"
+                            data-result-id="${this.escapeHtmlAttr(hit.document.id)}"
                             data-result-position="${index}"
                             aria-label="${title.replace(/<[^>]*>/g, '')}">
                             <article class="${CSS_PREFIX}-result-item" role="article">
@@ -731,10 +744,27 @@ import Typesense from 'typesense';
                 delete defaultParams.query_by_weights;
             }
 
-            return {
+            const mergedParams = {
                 ...defaultParams,
                 ...customParams
             };
+
+            // Click analytics needs each hit's `id` in the response. A host
+            // that overrides `include_fields` may legitimately omit it, so
+            // re-add `id` when analytics is enabled — otherwise click events
+            // would report a null resultId.
+            if (this.isAnalyticsEnabled()) {
+                const fields = String(mergedParams.include_fields || '')
+                    .split(',')
+                    .map(f => f.trim())
+                    .filter(Boolean);
+                if (!fields.includes('id')) {
+                    fields.unshift('id');
+                    mergedParams.include_fields = fields.join(',');
+                }
+            }
+
+            return mergedParams;
         }
 
         handleKeydown(e) {

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -68,6 +68,12 @@ import Typesense from 'typesense';
             this.cachedElements = {};
             this.typesenseClient = null;
 
+            // Analytics: the query that produced the currently rendered
+            // results (used to attribute clicks), and the last query for
+            // which a `search` event was already emitted (de-dupes repeats).
+            this.lastQuery = '';
+            this.lastTrackedQuery = null;
+
             // Default English translations
             this.defaultI18n = {
                 searchPlaceholder: 'Search for anything',
@@ -149,6 +155,82 @@ import Typesense from 'typesense';
                 // If URL parsing fails, return the original value
                 return url;
             }
+        }
+
+        // Analytics is strictly opt-in: it is only active when the host page
+        // provides an endpoint to receive events. With no `analytics.endpoint`
+        // configured, the widget makes no requests beyond Typesense.
+        isAnalyticsEnabled() {
+            return !!(this.config.analytics && this.config.analytics.endpoint);
+        }
+
+        // Send a single analytics event. Uses navigator.sendBeacon so events
+        // survive page navigation (clicking a result unloads the page) and
+        // never block the UI thread, falling back to fetch(keepalive) where
+        // sendBeacon is unavailable. Fully fail-silent: any transport error,
+        // or a non-2xx response, must never surface to the reader or break
+        // search.
+        sendAnalyticsEvent(event) {
+            if (!this.isAnalyticsEnabled()) return;
+
+            try {
+                const { endpoint, siteId, token } = this.config.analytics;
+                const payload = {
+                    ...event,
+                    siteId: siteId || null,
+                    token: token || undefined,
+                    ts: Date.now()
+                };
+                const body = JSON.stringify(payload);
+
+                // sendBeacon is the preferred transport: it is fire-and-forget
+                // and is not cancelled when the document starts unloading.
+                if (navigator.sendBeacon) {
+                    const blob = new Blob([body], { type: 'application/json' });
+                    if (navigator.sendBeacon(endpoint, blob)) return;
+                }
+
+                // Fallback for environments without sendBeacon.
+                fetch(endpoint, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body,
+                    keepalive: true,
+                    mode: 'cors',
+                    credentials: 'omit'
+                }).catch(() => {});
+            } catch {
+                // Swallow everything — analytics must never affect search.
+            }
+        }
+
+        // Emit a `search` event for a settled query, plus a derived
+        // `zero_result` event when the query returned nothing. De-duplicated
+        // so re-running the same settled query (e.g. reopening the modal with
+        // a ?q= parameter) emits at most one `search` event.
+        trackSearch(query, resultCount) {
+            if (!this.isAnalyticsEnabled() || !query) return;
+            if (query === this.lastTrackedQuery) return;
+            this.lastTrackedQuery = query;
+
+            this.sendAnalyticsEvent({ type: 'search', q: query, resultCount });
+
+            if (resultCount === 0) {
+                this.sendAnalyticsEvent({ type: 'zero_result', q: query, resultCount: 0 });
+            }
+        }
+
+        // Emit a `click` event attributing a result selection to the query
+        // that produced it. Called before navigation; sendBeacon survives the
+        // unload that the navigation triggers.
+        trackClick(resultId, position) {
+            if (!this.isAnalyticsEnabled() || !this.lastQuery) return;
+            this.sendAnalyticsEvent({
+                type: 'click',
+                q: this.lastQuery,
+                resultId: resultId || null,
+                position: typeof position === 'number' ? position : null
+            });
         }
 
         async init() {
@@ -306,6 +388,18 @@ import Typesense from 'typesense';
                 }, 80);
             });
 
+            // Result clicks (delegated) — emit a click event before the
+            // browser navigates. Uses capture so it runs before the link's
+            // default navigation begins unloading the page.
+            if (this.hitsList) {
+                this.hitsList.addEventListener('click', (e) => {
+                    const link = e.target.closest(`.${CSS_PREFIX}-result-link`);
+                    if (!link) return;
+                    const position = Number(link.dataset.resultPosition);
+                    this.trackClick(link.dataset.resultId, Number.isNaN(position) ? null : position);
+                }, true);
+            }
+
             // Common searches
             this.attachCommonSearchListeners();
 
@@ -445,6 +539,10 @@ import Typesense from 'typesense';
             if (this.searchInput) {
                 this.searchInput.value = '';
             }
+            // Reset analytics session state so the next time the modal opens,
+            // the first search is emitted even if it repeats a prior query.
+            this.lastQuery = '';
+            this.lastTrackedQuery = null;
             this.handleSearch('');
 
             // Restore focus
@@ -500,6 +598,17 @@ import Typesense from 'typesense';
 
                 if (this.loadingState) this.loadingState.classList.add(`${CSS_PREFIX}-hidden`);
 
+                // Total matches across all pages; fall back to the hit count
+                // on this page when `found` is absent.
+                const resultCount = typeof results.found === 'number'
+                    ? results.found
+                    : results.hits.length;
+
+                // Remember the query behind the rendered results so a later
+                // result click can be attributed to it.
+                this.lastQuery = query;
+                this.trackSearch(query, resultCount);
+
                 if (results.hits.length === 0) {
                     if (this.emptyState) this.emptyState.classList.remove(`${CSS_PREFIX}-hidden`);
                     if (this.hitsList) {
@@ -514,7 +623,7 @@ import Typesense from 'typesense';
                 // Clear and populate results
                 this.hitsList.innerHTML = '';
 
-                const resultsHtml = results.hits.map(hit => {
+                const resultsHtml = results.hits.map((hit, index) => {
                     // Use highlighted content when available, otherwise fall back to original
                     const getHighlightedTitle = (fieldName, fallback) => {
                         if (this.config.enableHighlighting && hit.highlight && hit.highlight[fieldName]) {
@@ -549,6 +658,8 @@ import Typesense from 'typesense';
                     return `
                         <a href="${resultUrl}"
                             class="${CSS_PREFIX}-result-link"
+                            data-result-id="${hit.document.id || ''}"
+                            data-result-position="${index}"
                             aria-label="${title.replace(/<[^>]*>/g, '')}">
                             <article class="${CSS_PREFIX}-result-item" role="article">
                                 <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}</h3>
@@ -599,7 +710,7 @@ import Typesense from 'typesense';
                 query_by_weights: weights.join(','),
                 highlight_full_fields: highlightFields.join(','),
                 highlight_affix_num_tokens: 30,
-                include_fields: 'title,url,excerpt,plaintext,published_at,tags',
+                include_fields: 'id,title,url,excerpt,plaintext,published_at,tags',
                 typo_tolerance: false,
                 num_typos: 0,
                 prefix: true,
@@ -690,6 +801,8 @@ import Typesense from 'typesense';
             if (this.selectedIndex >= 0 && this.selectedIndex < results.length) {
                 const selectedElement = results[this.selectedIndex];
                 if (selectedElement.classList.contains(`${CSS_PREFIX}-result-link`)) {
+                    const position = Number(selectedElement.dataset.resultPosition);
+                    this.trackClick(selectedElement.dataset.resultId, Number.isNaN(position) ? null : position);
                     window.location.href = selectedElement.href;
                 } else {
                     this.searchInput.value = selectedElement.textContent.trim();


### PR DESCRIPTION
## Summary

- Adds an **opt-in** analytics emitter to `@magicpages/ghost-typesense-search-ui`. When the host page sets `analytics.endpoint`, the widget emits `search`, `zero_result`, and `click` events to that endpoint.
- Events are sent via `navigator.sendBeacon()` with a `fetch(..., { keepalive: true })` fallback, so `click` events are delivered even though clicking a result navigates away.
- The widget only **emits** — it ships no backend and points at whatever endpoint the operator configures. Self-hosters can target any compatible service or leave analytics off entirely.
- Privacy-first: no cookies, no client-side tracking identifier, no fingerprinting, no PII beyond the query text. All emission is fail-silent and can never affect the search experience.
- A `search` event is de-duplicated to once per settled query; reopening the modal starts a fresh session.
- Adds `id` to `include_fields` and renders it as `data-result-id` on each result link so `click` events can report which result was opened (mouse click and keyboard Enter both covered).
- Documents the `analytics` config block, the three event shapes, the transport, and the privacy posture in the search-ui README.

With no `analytics` config present, behaviour is unchanged and no requests are made beyond Typesense.

## Test plan

- [x] `npm run lint` passes (search-ui and full monorepo via turbo)
- [x] `npm test` passes (10/10 turbo tasks; search-ui has no test runner, verified via build)
- [x] `rollup` build produces `dist/search.min.js`; analytics logic confirmed present in the minified bundle; gzipped size unchanged at ~33 KB
- [ ] Manual: with `analytics.endpoint` set, a settled query fires one `search` event (and `zero_result` when empty), and opening a result fires one `click` event with the correct `resultId`/`position`
- [ ] Manual: with no `analytics` config, no requests are made beyond Typesense

close #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in analytics to track search activity and result interactions
  * Captures search queries, zero-result events, and click tracking on results
  * Privacy-first design ensures no personal data or tracking identifiers are collected

* **Documentation**
  * Updated documentation with analytics configuration and usage guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->