### PR TITLE
feat: semantic (hybrid) search via vector embeddings (close #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,51 @@ WEBHOOK_SECRET=your-secret-key  # Generate a random string
 
 Now your search index will automatically update when you publish, update, or delete posts!
 
+## Semantic search
+
+By default search is purely lexical. You can optionally enable **semantic (hybrid) search**, where Typesense ranks results by a fusion of keyword relevance and vector similarity — so a query matches on meaning, not just shared words. This needs no extra infrastructure: Typesense generates the embeddings itself.
+
+### 1. Add an embedding field to the collection schema
+
+Add a `float[]` field with an `embed` block to your `collection.fields` in `ghost-typesense.config.json`. The `from` fields are the content Typesense embeds; `model_config.model_name` selects the model.
+
+```json
+{
+  "collection": {
+    "name": "ghost",
+    "fields": [
+      { "name": "embedding", "type": "float[]", "optional": true,
+        "embed": {
+          "from": ["title", "plaintext", "excerpt"],
+          "model_config": { "model_name": "ts/all-MiniLM-L12-v2" }
+        }
+      }
+    ]
+  }
+}
+```
+
+> When you provide a custom `fields` array, the required content fields (`id`, `title`, `url`, `slug`, `html`, `plaintext`, `excerpt`, `published_at`, `updated_at`) are still enforced and merged in automatically, so you only need to add the `embedding` field itself.
+
+**Models.** You can use a built-in Typesense model (e.g. `ts/all-MiniLM-L12-v2`) which runs locally on the Typesense server at no per-document cost, or an external provider by passing its details in `model_config` (for example an OpenAI model with `model_name`, `api_key`). Built-in models keep everything self-contained; external models can offer higher quality at a per-document API cost.
+
+Then `init` and `sync` as usual — Typesense embeds each document at index time:
+
+```bash
+ghost-typesense init --config ghost-typesense.config.json
+ghost-typesense sync --config ghost-typesense.config.json
+```
+
+### 2. Enable hybrid querying in the search UI
+
+Set `semanticSearch: true` in your search config — see the [search-ui semantic search docs](packages/search-ui/README.md#semantic-search).
+
+### Requirements and tradeoffs
+
+- **Typesense version.** Auto-embedding with built-in models requires Typesense **v0.25.0 or newer** (the build that ships the ML models). External-provider embedding is available from the same versions.
+- **Memory.** Vector fields meaningfully increase a collection's RAM footprint. Benchmark on a representative slice of your content before enabling it for a large blog.
+- **Index time.** Generating embeddings adds latency to syncing. Built-in models add CPU time on the Typesense server; external providers add per-document API calls (and their cost). Large initial syncs take noticeably longer than lexical-only indexing.
+
 ## Packages
 
 | Package | Description |

--- a/packages/config/src/__tests__/index.test.ts
+++ b/packages/config/src/__tests__/index.test.ts
@@ -141,4 +141,74 @@ describe('Default Config Creation', () => {
 
     expect(config.collection.fields).toEqual(DEFAULT_COLLECTION_FIELDS);
   });
-}); 
+
+  it('should not add an embedding field by default (semantic search is opt-in)', () => {
+    expect(DEFAULT_COLLECTION_FIELDS.some((f) => f.name === 'embedding')).toBe(false);
+    expect(DEFAULT_COLLECTION_FIELDS.some((f) => 'embed' in f)).toBe(false);
+  });
+});
+
+describe('Semantic search field', () => {
+  const baseConfig = (embeddingField: unknown) => ({
+    ghost: { url: 'https://example.com', key: 'valid-key', version: 'v5.0' },
+    typesense: {
+      nodes: [{ host: 'localhost', port: 8108, protocol: 'http' }],
+      apiKey: 'valid-key'
+    },
+    collection: {
+      name: 'posts',
+      fields: [...DEFAULT_COLLECTION_FIELDS, embeddingField]
+    }
+  });
+
+  it('should accept and preserve an auto-embedding field', () => {
+    const config = validateConfig(
+      baseConfig({
+        name: 'embedding',
+        type: 'float[]',
+        optional: true,
+        embed: {
+          from: ['title', 'plaintext', 'excerpt'],
+          model_config: { model_name: 'ts/all-MiniLM-L12-v2' }
+        }
+      })
+    );
+
+    const embeddingField = config.collection.fields.find((f) => f.name === 'embedding');
+    expect(embeddingField).toBeDefined();
+    // The embed block must survive validation — otherwise Typesense would
+    // never generate vectors and semantic search would silently not work.
+    expect(embeddingField?.embed?.from).toEqual(['title', 'plaintext', 'excerpt']);
+    expect(embeddingField?.embed?.model_config.model_name).toBe('ts/all-MiniLM-L12-v2');
+  });
+
+  it('should preserve extra model_config keys for external providers', () => {
+    const config = validateConfig(
+      baseConfig({
+        name: 'embedding',
+        type: 'float[]',
+        optional: true,
+        embed: {
+          from: ['title'],
+          model_config: { model_name: 'openai/text-embedding-3-small', api_key: 'sk-test' }
+        }
+      })
+    );
+
+    const embeddingField = config.collection.fields.find((f) => f.name === 'embedding');
+    expect((embeddingField?.embed?.model_config as Record<string, unknown>).api_key).toBe('sk-test');
+  });
+
+  it('should reject an embed block with no source fields', () => {
+    expect(() =>
+      validateConfig(
+        baseConfig({
+          name: 'embedding',
+          type: 'float[]',
+          optional: true,
+          embed: { from: [], model_config: { model_name: 'ts/all-MiniLM-L12-v2' } }
+        })
+      )
+    ).toThrow();
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,6 +42,22 @@ export const TypesenseConfigSchema = z.object({
 });
 
 /**
+ * Auto-embedding configuration for a vector field.
+ *
+ * When present on a `float[]` field, Typesense generates the field's vector
+ * server-side from the listed source fields, using either a built-in model
+ * (e.g. `ts/all-MiniLM-L12-v2`) or an external provider (OpenAI, etc.) via
+ * `model_config`. See the Typesense vector-search documentation for the full
+ * set of `model_config` options (`api_key`, `url`, `access_token`, ...).
+ */
+export const EmbedSchema = z.object({
+  from: z.array(z.string()).min(1),
+  model_config: z.object({
+    model_name: z.string().min(1)
+  }).passthrough()
+});
+
+/**
  * Collection field configuration schema
  */
 export const CollectionFieldSchema = z.object({
@@ -50,7 +66,12 @@ export const CollectionFieldSchema = z.object({
   facet: z.boolean().optional(),
   index: z.boolean().optional(),
   optional: z.boolean().optional(),
-  sort: z.boolean().optional()
+  sort: z.boolean().optional(),
+  // Vector-search support. `embed` opts a `float[]` field into auto-embedding;
+  // `num_dim` declares the dimension when supplying vectors manually (it is
+  // inferred from the model when `embed` is used).
+  embed: EmbedSchema.optional(),
+  num_dim: z.number().int().positive().optional()
 }).transform(data => ({
   ...data,
   optional: data.optional ?? false
@@ -144,6 +165,7 @@ export const ConfigSchema = z.object({
 export type GhostConfig = z.infer<typeof GhostConfigSchema>;
 export type TypesenseNode = z.infer<typeof TypesenseNodeSchema>;
 export type TypesenseConfig = z.infer<typeof TypesenseConfigSchema>;
+export type Embed = z.infer<typeof EmbedSchema>;
 export type CollectionField = z.infer<typeof CollectionFieldSchema>;
 export type CollectionConfig = z.infer<typeof CollectionConfigSchema>;
 export type Config = z.infer<typeof ConfigSchema>;

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -56,12 +56,17 @@ vi.mock('@ts-ghost/content-api', () => {
   };
 });
 
-vi.mock('typesense', () => {
-  const mockDocuments = {
-    delete: vi.fn().mockResolvedValue(true),
-    upsert: vi.fn().mockResolvedValue(true)
-  };
+// Stable spies so tests can inspect what was sent to Typesense. The import
+// import() call (`documents().import`) is used by batched indexing; upsert by
+// single-post indexing; create by collection (re)creation.
+const mockDocuments = {
+  delete: vi.fn().mockResolvedValue(true),
+  upsert: vi.fn().mockResolvedValue(true),
+  import: vi.fn().mockResolvedValue([{ success: true }])
+};
+const mockCreate = vi.fn().mockResolvedValue(true);
 
+vi.mock('typesense', () => {
   return {
     Client: vi.fn().mockImplementation(() => ({
       collections: (name?: string) => {
@@ -73,7 +78,7 @@ vi.mock('typesense', () => {
         }
         return {
           retrieve: vi.fn().mockResolvedValue([]),
-          create: vi.fn().mockResolvedValue(true)
+          create: mockCreate
         };
       }
     }))
@@ -111,6 +116,9 @@ describe('GhostTypesenseManager', () => {
   };
 
   beforeEach(() => {
+    mockDocuments.upsert.mockClear();
+    mockDocuments.import.mockClear();
+    mockCreate.mockClear();
     manager = new GhostTypesenseManager(testConfig);
   });
 
@@ -143,4 +151,64 @@ describe('GhostTypesenseManager', () => {
       await expect(manager.clearCollection()).resolves.not.toThrow();
     });
   });
-}); 
+});
+
+describe('GhostTypesenseManager — semantic search', () => {
+  const embeddingField = {
+    name: 'embedding',
+    type: 'float[]' as const,
+    optional: true,
+    embed: {
+      from: ['title', 'plaintext', 'excerpt'],
+      model_config: { model_name: 'ts/all-MiniLM-L12-v2' }
+    }
+  };
+
+  const semanticConfig: Config = {
+    ghost: { url: 'https://test.com', key: 'test-key', version: 'v5.0' },
+    typesense: {
+      nodes: [{ host: 'localhost', port: 8108, protocol: 'http' }],
+      apiKey: 'test-key'
+    },
+    collection: {
+      name: 'test-collection',
+      fields: [
+        { name: 'id', type: 'string', optional: false },
+        { name: 'title', type: 'string', optional: false },
+        { name: 'slug', type: 'string', optional: false },
+        { name: 'html', type: 'string', optional: true },
+        { name: 'excerpt', type: 'string', optional: true },
+        { name: 'published_at', type: 'int64', optional: false },
+        { name: 'updated_at', type: 'int64', optional: false },
+        embeddingField
+      ]
+    }
+  };
+
+  beforeEach(() => {
+    mockDocuments.upsert.mockClear();
+    mockCreate.mockClear();
+  });
+
+  it('passes the embed config through to the created collection schema', async () => {
+    const manager = new GhostTypesenseManager(semanticConfig);
+    await manager.initializeCollection();
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const schema = mockCreate.mock.calls[0]![0] as {
+      fields: Array<{ name: string; embed?: unknown }>;
+    };
+    const field = schema.fields.find((f) => f.name === 'embedding');
+    expect(field?.embed).toEqual(embeddingField.embed);
+  });
+
+  it('does not write a value into the auto-embedding field when indexing', async () => {
+    const manager = new GhostTypesenseManager(semanticConfig);
+    await manager.indexPost('test-post-1');
+
+    expect(mockDocuments.upsert).toHaveBeenCalledTimes(1);
+    const document = mockDocuments.upsert.mock.calls[0]![0] as Record<string, unknown>;
+    // Typesense generates the vector itself; supplying one would be rejected.
+    expect('embedding' in document).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 import { TSGhostContentAPI, type Post as GhostPost } from '@ts-ghost/content-api';
 import { Client } from 'typesense';
+import type { CollectionFieldSchema } from 'typesense/lib/Typesense/Collection';
 import type { Config } from '@magicpages/ghost-typesense-config';
 
 export interface Post {
@@ -45,6 +46,31 @@ export class GhostTypesenseManager {
   }
 
   /**
+   * Build the Typesense collection schema from the configured fields.
+   *
+   * Only defined properties are copied so the payload stays clean, and the
+   * vector-search properties (`embed`, `num_dim`) are passed through when
+   * present — these are what opt a field into semantic search.
+   * @private
+   */
+  private buildCollectionSchema() {
+    return {
+      name: this.collectionName,
+      fields: this.config.collection.fields.map((field): CollectionFieldSchema => {
+        const mapped: CollectionFieldSchema = { name: field.name, type: field.type };
+        if (field.facet !== undefined) mapped.facet = field.facet;
+        if (field.index !== undefined) mapped.index = field.index;
+        if (field.optional !== undefined) mapped.optional = field.optional;
+        if (field.sort !== undefined) mapped.sort = field.sort;
+        if (field.embed !== undefined) mapped.embed = field.embed;
+        if (field.num_dim !== undefined) mapped.num_dim = field.num_dim;
+        return mapped;
+      }),
+      enable_nested_fields: true // Enable nested fields support
+    };
+  }
+
+  /**
    * Initialize the Typesense collection with the specified schema
    */
   async initializeCollection(): Promise<void> {
@@ -56,21 +82,7 @@ export class GhostTypesenseManager {
       await collection.delete();
     }
 
-    // Add support for nested fields
-    const schema = {
-      name: this.collectionName,
-      fields: this.config.collection.fields.map((field) => ({
-        name: field.name,
-        type: field.type,
-        facet: field.facet,
-        index: field.index,
-        optional: field.optional,
-        sort: field.sort
-      })),
-      enable_nested_fields: true // Enable nested fields support
-    };
-
-    await this.typesense.collections().create(schema);
+    await this.typesense.collections().create(this.buildCollectionSchema());
   }
 
   /**
@@ -153,6 +165,12 @@ export class GhostTypesenseManager {
     // Add any additional fields specified in the config
     // Only add fields that haven't already been transformed to avoid overriding custom transformations
     this.config.collection.fields.forEach((field) => {
+      // Skip auto-embedding fields: Typesense generates their vectors from the
+      // configured source fields at index time, and supplying a value would be
+      // rejected.
+      if (field.embed) {
+        return;
+      }
       const value = post[field.name as keyof GhostPost];
       if (!(field.name in transformed) && value !== undefined && value !== null) {
         transformed[field.name] = value;
@@ -459,18 +477,6 @@ export class GhostTypesenseManager {
     const collection = this.typesense.collections(this.collectionName);
     await collection.delete();
 
-    const schema = {
-      name: this.collectionName,
-      fields: this.config.collection.fields.map((field) => ({
-        name: field.name,
-        type: field.type,
-        facet: field.facet,
-        index: field.index,
-        optional: field.optional,
-        sort: field.sort
-      }))
-    };
-
-    await this.typesense.collections().create(schema);
+    await this.typesense.collections().create(this.buildCollectionSchema());
   }
 } 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -89,6 +89,8 @@ window.__MP_SEARCH_CONFIG__ = {
 | `locale` | `String` | No | `'en'` | Locale identifier for i18n translations |
 | `i18n` | `Object` | No | `{}` | Translation overrides for UI strings (see [Internationalization](#internationalization-i18n)) |
 | `analytics` | `Object` | No | — | Opt-in search analytics — emit query, click, and zero-result events to your own endpoint (see [Analytics](#analytics)) |
+| `semanticSearch` | `Boolean` | No | `false` | Enable hybrid (keyword + vector) search against an embedding field (see [Semantic search](#semantic-search)) |
+| `embeddingFieldName` | `String` | No | `'embedding'` | Name of the collection's embedding field, used when `semanticSearch` is enabled |
 
 ### Search Fields Configuration
 
@@ -194,6 +196,24 @@ window.__MP_SEARCH_CONFIG__ = {
 ```
 
 > **Note:** If you provide a custom `query_by` without a matching `query_by_weights`, the default weights are automatically removed to avoid mismatches. If you override `query_by`, you should also provide `query_by_weights`.
+
+## Semantic search
+
+Semantic (hybrid) search is **opt-in and disabled by default**. By default the widget runs purely lexical queries — keyword matching with prefix matching, optional typo tolerance, and field weighting.
+
+When the collection has a vector embedding field, set `semanticSearch: true` and the widget appends that field to `query_by`, so Typesense fuses keyword relevance with vector similarity. This lets a search for "growing tomatoes" surface a post about "vegetable garden tips" even without overlapping words.
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    semanticSearch: true,
+    embeddingFieldName: 'embedding' // optional, defaults to 'embedding'
+};
+```
+
+This requires the collection to have been created with an auto-embedding field. That is configured on the indexing side — see the [collection schema and semantic search documentation in the project README](../../README.md#semantic-search). When `semanticSearch` is enabled but the collection has no matching embedding field, Typesense returns an error for the query; leave it `false` for lexical-only collections.
+
+You can still combine this with `typesenseSearchParams` — the embedding field is appended to whatever `query_by` is in effect, and `query_by_weights` is left untouched (the vector field carries no keyword weight).
 
 ## Analytics
 

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -764,6 +764,23 @@ import Typesense from 'typesense';
                 }
             }
 
+            // Semantic (hybrid) search: when enabled, append the embedding
+            // field to `query_by`. Typesense then fuses keyword and vector
+            // relevance, auto-embedding the query against the field's model.
+            // The vector field carries no keyword weight, so query_by_weights
+            // is left untouched. When disabled, queries stay purely lexical.
+            if (this.config.semanticSearch) {
+                const embeddingField = this.config.embeddingFieldName || 'embedding';
+                const queryFields = String(mergedParams.query_by || '')
+                    .split(',')
+                    .map(f => f.trim())
+                    .filter(Boolean);
+                if (!queryFields.includes(embeddingField)) {
+                    queryFields.push(embeddingField);
+                    mergedParams.query_by = queryFields.join(',');
+                }
+            }
+
             return mergedParams;
         }
 


### PR DESCRIPTION
## Summary

Adds **optional** semantic (hybrid) search built on Typesense's native vector support — no extra infrastructure, since Typesense generates the embeddings itself. Disabled by default; lexical search is byte-for-byte unchanged when off.

- **`config`** — the collection field schema now carries an optional `embed` block (`from` source fields + `model_config`) and `num_dim`. `model_config` is passthrough, so both built-in models (e.g. `ts/all-MiniLM-L12-v2`) and external providers (OpenAI etc., with `api_key`/`url`) work. No embedding field is added to the defaults.
- **`core`** — a shared `buildCollectionSchema()` passes `embed`/`num_dim` through to Typesense on collection create/recreate (both call sites previously dropped unknown field properties). `transformPost` never writes a value into an auto-embedding field — Typesense generates the vector and would reject a supplied one. The shared builder also gives `clearCollection` the `enable_nested_fields` flag it previously omitted.
- **`search-ui`** — new `semanticSearch` (+ optional `embeddingFieldName`) config. When enabled, the embedding field is appended to `query_by` for a hybrid keyword+vector query; `query_by_weights` is left untouched. Falls back to lexical when off.
- **Docs** — root README documents the `embed` schema, built-in vs external models, the minimum Typesense version (v0.25.0+), and the memory/index-time tradeoffs; search-ui README documents the query-side toggle.

## Acceptance criteria

- [x] Default (disabled): schema and queries unchanged
- [x] Enabled: collection created with the embedding field; documents embedded at index time
- [x] Hybrid query when embedding field present; lexical fallback otherwise
- [x] Both built-in and external embedding models configurable
- [x] README documents enabling, models, min version, and tradeoffs

## Test plan

- [x] `npm run lint` (5/5)
- [x] `npm run typecheck` (6/6)
- [x] `npm test` — added config tests (embed survives validation, external `model_config` keys preserved, empty `from` rejected, default has no embedding field) and core tests (`embed` reaches `collections().create`; indexing writes no value into the embedding field)
- [x] `npm run build` (search-ui bundle includes the hybrid-query logic)
- [x] Manual: against a Typesense ≥ v0.25 collection with an `embed` field, confirm hybrid results and that lexical-only collections still work with `semanticSearch: false`

close #14