### PR TITLE
feat: dynamic and curated search suggestions (close #15)

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -82,7 +82,9 @@ window.__MP_SEARCH_CONFIG__ = {
 | `collectionName` | `String` | Yes | — | Name of your Typesense collection |
 | `theme` | `String` | No | `'system'` | UI theme: `'light'`, `'dark'`, or `'system'` (respects OS preference) |
 | `enableHighlighting` | `Boolean` | No | `true` | Whether to highlight search terms in results |
-| `commonSearches` | `Array` | No | `[]` | Array of suggested search terms to display |
+| `commonSearches` | `Array` | No | `[]` | Static fallback list of suggested search terms (see [Search suggestions](#search-suggestions)) |
+| `pinnedSearches` | `Array` | No | `[]` | Publisher-curated terms, always shown first (see [Search suggestions](#search-suggestions)) |
+| `suggestionsUrl` | `String` | No | — | URL fetched on modal open for dynamic suggestions (see [Search suggestions](#search-suggestions)) |
 | `searchFields` | `Object` | No | See below | Customize field weights and highlighting |
 | `typesenseSearchParams` | `Object` | No | `{}` | Override default Typesense search parameters (sorting, filtering, etc.) |
 | `transformToRelativeUrls` | `Boolean` | No | `false` | Convert result URLs to relative paths (useful for proxy domains or custom domain setups) |
@@ -194,6 +196,40 @@ window.__MP_SEARCH_CONFIG__ = {
 ```
 
 > **Note:** If you provide a custom `query_by` without a matching `query_by_weights`, the default weights are automatically removed to avoid mismatches. If you override `query_by`, you should also provide `query_by_weights`.
+
+## Search suggestions
+
+Before a reader types anything, the modal can show a list of suggested searches. Suggestions come from up to three sources, resolved in this order:
+
+1. **`pinnedSearches`** — publisher-curated terms, always shown first in the order given.
+2. **`suggestionsUrl`** — terms fetched from a URL you provide (e.g. your most popular recent queries).
+3. **`commonSearches`** — a static fallback list.
+
+Duplicate terms across the three sources are collapsed (case-insensitively), so a pinned term won't also appear from the fetched or static lists.
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    pinnedSearches: ['New feature launch'],            // always first
+    suggestionsUrl: 'https://example.com/suggestions', // fetched on open
+    commonSearches: ['Getting started', 'Pricing']     // fallback
+};
+```
+
+### `suggestionsUrl`
+
+The URL is fetched **once per page session, lazily the first time the modal opens** — never on page load, so readers who never search incur no request. The result is cached for the rest of the session.
+
+The endpoint may return either a bare array of strings or an object with a `suggestions` array:
+
+```json
+["getting started", "pricing", "api reference"]
+```
+```json
+{ "suggestions": ["getting started", "pricing", "api reference"] }
+```
+
+The fetch is **fail-silent**: if the request errors or returns a non-success status, the widget falls back to `pinnedSearches` + `commonSearches` with no visible error, and does not retry that URL for the rest of the session. The widget is backend-agnostic — it only consumes the URL and does not define where the suggestions come from.
 
 ## Analytics
 

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -74,6 +74,12 @@ import Typesense from 'typesense';
             this.lastQuery = '';
             this.lastTrackedQuery = null;
 
+            // Suggestions fetched from `suggestionsUrl`, cached for the page
+            // session. `suggestionsFetched` guards against re-fetching (and
+            // re-failing) on every modal open.
+            this.fetchedSuggestions = [];
+            this.suggestionsFetched = false;
+
             // Default English translations
             this.defaultI18n = {
                 searchPlaceholder: 'Search for anything',
@@ -120,7 +126,8 @@ import Typesense from 'typesense';
 
             this.config = {
                 ...defaultConfig,
-                commonSearches: defaultConfig.commonSearches || []
+                commonSearches: defaultConfig.commonSearches || [],
+                pinnedSearches: defaultConfig.pinnedSearches || []
             };
 
             if (!this.config.typesenseNodes || !this.config.typesenseApiKey || !this.config.collectionName) {
@@ -246,6 +253,69 @@ import Typesense from 'typesense';
             });
         }
 
+        // Resolve the suggestion list shown in the empty state, in priority
+        // order: pinned terms first (publisher-curated), then any terms
+        // fetched from `suggestionsUrl`, then the static `commonSearches`
+        // fallback. Duplicates are collapsed (case-insensitively) so a term
+        // never appears twice.
+        getSuggestions() {
+            const ordered = [
+                ...(this.config.pinnedSearches || []),
+                ...(this.fetchedSuggestions || []),
+                ...(this.config.commonSearches || [])
+            ];
+
+            const seen = new Set();
+            const result = [];
+            for (const term of ordered) {
+                if (typeof term !== 'string') continue;
+                const trimmed = term.trim();
+                if (!trimmed) continue;
+                const key = trimmed.toLowerCase();
+                if (seen.has(key)) continue;
+                seen.add(key);
+                result.push(trimmed);
+            }
+            return result;
+        }
+
+        // Fetch suggestions from `suggestionsUrl` once per page session. The
+        // endpoint may return either a bare string[] or { suggestions: [...] }.
+        // Fail-silent: any error leaves fetchedSuggestions empty, so the empty
+        // state falls back to pinned + commonSearches. The fetched flag is set
+        // regardless of outcome so a failing URL is not retried on every open.
+        async fetchSuggestions() {
+            if (this.suggestionsFetched || !this.config.suggestionsUrl) return;
+            this.suggestionsFetched = true;
+
+            try {
+                const response = await fetch(this.config.suggestionsUrl, {
+                    method: 'GET',
+                    mode: 'cors',
+                    credentials: 'omit'
+                });
+                if (!response.ok) return;
+
+                const data = await response.json();
+                const list = Array.isArray(data) ? data : data?.suggestions;
+                if (Array.isArray(list)) {
+                    this.fetchedSuggestions = list.filter(t => typeof t === 'string');
+                }
+            } catch {
+                // Swallow — a failed fetch must not surface to the reader.
+            }
+        }
+
+        // Rebuild the suggestions block in place from the current resolved
+        // list. Replacing the block's contents discards the old delegated
+        // click listener with its container, so a single re-attach is correct
+        // (no double-binding).
+        renderSuggestions() {
+            if (!this.commonSearches) return;
+            this.commonSearches.innerHTML = this.getCommonSearchesInnerHtml();
+            this.attachCommonSearchListeners();
+        }
+
         async init() {
             this.createShadowContent();
             this.cacheElements();
@@ -332,29 +402,42 @@ import Typesense from 'typesense';
         }
 
         getCommonSearchesHtml() {
-            if (!this.config.commonSearches?.length) {
+            return `
+                <div class="${CSS_PREFIX}-common-searches">
+                    ${this.getCommonSearchesInnerHtml()}
+                </div>
+            `;
+        }
+
+        // The inner markup of the suggestions block, so it can be re-rendered
+        // independently once dynamic suggestions have been fetched. Suggestion
+        // strings may originate from a remote `suggestionsUrl`, so every term
+        // is escaped before being interpolated into the markup.
+        getCommonSearchesInnerHtml() {
+            const suggestions = this.getSuggestions();
+
+            if (!suggestions.length) {
                 return `
-                    <div class="${CSS_PREFIX}-common-searches">
-                        <div class="${CSS_PREFIX}-empty-message">${this.t('emptyStateMessage')}</div>
-                    </div>
+                    <div class="${CSS_PREFIX}-empty-message">${this.t('emptyStateMessage')}</div>
                 `;
             }
 
             return `
-                <div class="${CSS_PREFIX}-common-searches">
-                    <div class="${CSS_PREFIX}-common-searches-title" role="heading" aria-level="2">
-                        ${this.t('commonSearchesTitle')}
-                    </div>
-                    <div id="${CSS_PREFIX}-common-searches-container" role="list">
-                        ${this.config.commonSearches.map(search => `
+                <div class="${CSS_PREFIX}-common-searches-title" role="heading" aria-level="2">
+                    ${this.t('commonSearchesTitle')}
+                </div>
+                <div id="${CSS_PREFIX}-common-searches-container" role="list">
+                    ${suggestions.map(search => {
+                        const safe = this.escapeHtmlAttr(search);
+                        return `
                             <button type="button"
                                 class="${CSS_PREFIX}-common-search-btn"
-                                data-search="${search}"
+                                data-search="${safe}"
                                 role="listitem">
-                                ${search}
+                                ${safe}
                             </button>
-                        `).join('')}
-                    </div>
+                        `;
+                    }).join('')}
                 </div>
             `;
         }
@@ -521,6 +604,14 @@ import Typesense from 'typesense';
             setTimeout(() => {
                 this.searchInput.focus();
             }, 50);
+
+            // Lazily fetch dynamic suggestions on first open (no-op without a
+            // suggestionsUrl), then re-render the list. Done after the modal is
+            // shown so opening stays instant; the suggestions update in place
+            // when the fetch resolves.
+            if (this.config.suggestionsUrl && !this.suggestionsFetched) {
+                this.fetchSuggestions().then(() => this.renderSuggestions());
+            }
 
             // Update URL
             if (window.location.hash !== '#/search') {


### PR DESCRIPTION
## Summary

The empty-state suggestion list was a single static `commonSearches` array. This adds two higher-priority sources:

- **`pinnedSearches`** — publisher-curated terms, always rendered first, in order.
- **`suggestionsUrl`** — terms fetched from a configurable URL (accepts a bare `string[]` or `{ suggestions: [...] }`).

The displayed list resolves as **pinned → fetched → commonSearches**, with duplicates collapsed case-insensitively.

Behaviour:
- The `suggestionsUrl` fetch is **lazy** (first modal open, not page load), **cached for the page session**, and **fail-silent** — a failed/non-2xx response falls back to pinned + commonSearches and isn't retried for the session.
- The widget stays backend-agnostic: it consumes a URL, it does not define the source.
- Because fetched terms can now come from a remote endpoint, every suggestion string is escaped before being written into the markup (reusing the `escapeHtmlAttr` helper).

With only `commonSearches` set, behaviour is unchanged.

## Acceptance criteria

- [x] Only `commonSearches` set → unchanged
- [x] `pinnedSearches` always first, in order
- [x] `suggestionsUrl` results render after pinned; fall back to `commonSearches` on failure
- [x] Fetch on modal open (not page load), cached for the session
- [x] Duplicates collapsed across all three sources
- [x] README documents the options, response shape, and resolution order

## Test plan

- [x] `npm run lint` (5/5)
- [x] `npm run build` — suggestions logic confirmed in the bundle
- [ ] Manual: with `suggestionsUrl` set, open the modal → suggestions update in place after fetch; with a broken URL → falls back silently; pinned terms always lead; duplicates don't repeat

> Note: `packages/search-ui` has no unit-test runner (`test` is `exit 0`), so this is verified via lint + build + manual trace, consistent with the analytics and semantic-search PRs.

close #15