### PR TITLE
feat: reader-facing facet filters in the search UI (close #16)

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -91,6 +91,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `analytics` | `Object` | No | — | Opt-in search analytics — emit query, click, and zero-result events to your own endpoint (see [Analytics](#analytics)) |
 | `semanticSearch` | `Boolean` | No | `false` | Enable hybrid (keyword + vector) search against an embedding field (see [Semantic search](#semantic-search)) |
 | `embeddingFieldName` | `String` | No | `'embedding'` | Name of the collection's embedding field, used when `semanticSearch` is enabled |
+| `facets` | `Array` | No | `[]` | Reader-facing filter controls for faceted fields (see [Filters](#filters)) |
 
 ### Search Fields Configuration
 
@@ -196,6 +197,35 @@ window.__MP_SEARCH_CONFIG__ = {
 ```
 
 > **Note:** If you provide a custom `query_by` without a matching `query_by_weights`, the default weights are automatically removed to avoid mismatches. If you override `query_by`, you should also provide `query_by_weights`.
+
+## Filters
+
+Reader-facing **facets** let readers narrow results by a faceted field such as tags or authors. They are **opt-in**: with no `facets` config the UI and queries are unchanged.
+
+Add a `facets` array, one entry per field you want to expose. Each field must be `facet: true` in the collection schema (the defaults already facet `tags`, `tags.name`, `tags.slug`, and `authors`).
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    facets: [
+        { field: 'tags.name', label: 'Topics',  limit: 10 },
+        { field: 'authors',   label: 'Authors', limit: 5 }
+    ]
+};
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `field` | `String` | Yes | A faceted collection field (e.g. `tags.name`, `authors`) |
+| `label` | `String` | No | Heading shown above the field's chips (defaults to the field name) |
+| `limit` | `Number` | No | Maximum number of values shown for the field (defaults to 10) |
+
+Behaviour:
+
+- When a query is active, each configured field renders as a row of selectable chips with a live result count. Chips are `<button>` elements with `aria-pressed`, so they are keyboard-focusable and toggle with Enter/Space.
+- Selecting one or more values filters the results and refreshes the counts. Values within a field are OR-ed; different fields are AND-ed together.
+- Selections can be cleared individually (toggling a chip off) or all at once via the **Clear filters** button.
+- A publisher-provided `typesenseSearchParams.filter_by` is **preserved**: facet selections are AND-ed with it rather than overwriting it.
 
 ## Semantic search
 
@@ -353,6 +383,8 @@ window.__MP_SEARCH_CONFIG__ = {
 | `ariaResultsLabel` | "Search results" | ARIA label for results region |
 | `ariaArticleExcerpt` | "Article excerpt" | ARIA label for article excerpts |
 | `ariaModalLabel` | "Search" | ARIA label for modal |
+| `ariaFacetsLabel` | "Filters" | ARIA label for the facet filter group |
+| `clearFiltersLabel` | "Clear filters" | Label for the button that clears active facet filters |
 | `untitledPost` | "Untitled" | Fallback for posts without titles |
 
 ### Example Translations

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -74,6 +74,11 @@ import Typesense from 'typesense';
             this.lastQuery = '';
             this.lastTrackedQuery = null;
 
+            // Reader-selected facet values, keyed by field name. Each value is
+            // a Set of the chosen values for that field. Reset when the modal
+            // closes. Only used when `facets` is configured.
+            this.selectedFacets = {};
+
             // Default English translations
             this.defaultI18n = {
                 searchPlaceholder: 'Search for anything',
@@ -88,6 +93,8 @@ import Typesense from 'typesense';
                 ariaResultsLabel: 'Search results',
                 ariaArticleExcerpt: 'Article excerpt',
                 ariaModalLabel: 'Search',
+                ariaFacetsLabel: 'Filters',
+                clearFiltersLabel: 'Clear filters',
                 untitledPost: 'Untitled'
             };
         }
@@ -120,7 +127,8 @@ import Typesense from 'typesense';
 
             this.config = {
                 ...defaultConfig,
-                commonSearches: defaultConfig.commonSearches || []
+                commonSearches: defaultConfig.commonSearches || [],
+                facets: defaultConfig.facets || []
             };
 
             if (!this.config.typesenseNodes || !this.config.typesenseApiKey || !this.config.collectionName) {
@@ -300,6 +308,7 @@ import Typesense from 'typesense';
                             </div>
                             <div class="${CSS_PREFIX}-results-container">
                                 ${this.getCommonSearchesHtml()}
+                                <div id="${CSS_PREFIX}-facets" class="${CSS_PREFIX}-facets ${CSS_PREFIX}-hidden" role="group" aria-label="${this.t('ariaFacetsLabel')}"></div>
                                 <div id="${CSS_PREFIX}-hits" class="${CSS_PREFIX}-hits-list" role="region" aria-label="${this.t('ariaResultsLabel')}"></div>
                                 <div id="${CSS_PREFIX}-loading" class="${CSS_PREFIX}-loading ${CSS_PREFIX}-hidden" role="status" aria-live="polite">
                                     <div class="${CSS_PREFIX}-spinner" aria-hidden="true"></div>
@@ -326,6 +335,7 @@ import Typesense from 'typesense';
             this.searchInput = this.shadowRoot.querySelector(`.${CSS_PREFIX}-input`);
             this.searchForm = this.shadowRoot.querySelector(`.${CSS_PREFIX}-form`);
             this.hitsList = this.shadowRoot.querySelector(`#${CSS_PREFIX}-hits`);
+            this.facetsContainer = this.shadowRoot.querySelector(`#${CSS_PREFIX}-facets`);
             this.commonSearches = this.shadowRoot.querySelector(`.${CSS_PREFIX}-common-searches`);
             this.loadingState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-loading`);
             this.emptyState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-empty`);
@@ -415,6 +425,9 @@ import Typesense from 'typesense';
 
             // Common searches
             this.attachCommonSearchListeners();
+
+            // Facet chips (delegated; container persists across re-renders)
+            this.attachFacetListeners();
 
             // Keyboard shortcuts (attached to document, outside shadow DOM)
             document.addEventListener('keydown', (e) => {
@@ -556,6 +569,8 @@ import Typesense from 'typesense';
             // the first search is emitted even if it repeats a prior query.
             this.lastQuery = '';
             this.lastTrackedQuery = null;
+            // Clear any active facet filters so a new session starts unfiltered.
+            this.selectedFacets = {};
             this.handleSearch('');
 
             // Restore focus
@@ -578,6 +593,7 @@ import Typesense from 'typesense';
                 if (this.commonSearches) this.commonSearches.classList.remove(`${CSS_PREFIX}-hidden`);
                 if (this.emptyState) this.emptyState.classList.add(`${CSS_PREFIX}-hidden`);
                 if (this.loadingState) this.loadingState.classList.add(`${CSS_PREFIX}-hidden`);
+                if (this.facetsContainer) this.facetsContainer.classList.add(`${CSS_PREFIX}-hidden`);
                 return;
             }
 
@@ -621,6 +637,13 @@ import Typesense from 'typesense';
                 // result click can be attributed to it.
                 this.lastQuery = query;
                 this.trackSearch(query, resultCount);
+
+                // Render facet chips from the returned counts. Done before the
+                // no-results check so a reader can still clear a filter that
+                // produced zero results.
+                if (this.config.facets?.length) {
+                    this.renderFacets(results.facet_counts);
+                }
 
                 if (results.hits.length === 0) {
                     if (this.emptyState) this.emptyState.classList.remove(`${CSS_PREFIX}-hidden`);
@@ -691,6 +714,7 @@ import Typesense from 'typesense';
                     this.hitsList.innerHTML = '';
                     this.hitsList.classList.add(`${CSS_PREFIX}-hidden`);
                 }
+                if (this.facetsContainer) this.facetsContainer.classList.add(`${CSS_PREFIX}-hidden`);
             }
         }
 
@@ -781,7 +805,160 @@ import Typesense from 'typesense';
                 }
             }
 
+            // Reader-facing facets: request facet counts for the configured
+            // fields and AND any selected values into `filter_by`, preserving a
+            // publisher-configured filter rather than overwriting it.
+            if (this.config.facets?.length) {
+                mergedParams.facet_by = this.config.facets.map(f => f.field).join(',');
+
+                const maxValues = Math.max(...this.config.facets.map(f => f.limit || 10));
+                if (Number.isFinite(maxValues)) {
+                    mergedParams.max_facet_values = maxValues;
+                }
+
+                const composed = this.composeFilterBy(mergedParams.filter_by);
+                if (composed) {
+                    mergedParams.filter_by = composed;
+                } else {
+                    delete mergedParams.filter_by;
+                }
+            }
+
             return mergedParams;
+        }
+
+        // Build the `filter_by` clause for the currently selected facet values:
+        // values within a field are OR-ed, and the per-field clauses are
+        // AND-ed together. Values are backtick-quoted (with any backticks
+        // stripped) so spaces and commas don't break the expression.
+        buildFacetFilter() {
+            const clauses = [];
+            for (const facet of this.config.facets || []) {
+                const values = this.selectedFacets[facet.field];
+                if (!values || values.size === 0) continue;
+                const quoted = [...values]
+                    .map(v => `\`${String(v).replace(/`/g, '')}\``)
+                    .join(',');
+                clauses.push(`${facet.field}:=[${quoted}]`);
+            }
+            return clauses.join(' && ');
+        }
+
+        // Combine the selected-facet filter with a publisher-provided
+        // `filter_by` (from typesenseSearchParams). Both sides are wrapped in
+        // parentheses and AND-ed so neither clobbers the other. Returns an
+        // empty string when there is nothing to filter by.
+        composeFilterBy(existingFilter) {
+            const facetFilter = this.buildFacetFilter();
+            const existing = (existingFilter || '').trim();
+
+            if (existing && facetFilter) {
+                return `(${existing}) && (${facetFilter})`;
+            }
+            return existing || facetFilter;
+        }
+
+        // Render the facet chip groups from the facet counts Typesense returned
+        // for the current query. Each value is a toggle button (aria-pressed
+        // reflects selection); a "clear filters" button appears when anything
+        // is selected. Hidden entirely when no facets are configured or no
+        // counts came back.
+        renderFacets(facetCounts) {
+            if (!this.facetsContainer) return;
+
+            if (!this.config.facets?.length || !Array.isArray(facetCounts) || facetCounts.length === 0) {
+                this.facetsContainer.innerHTML = '';
+                this.facetsContainer.classList.add(`${CSS_PREFIX}-hidden`);
+                return;
+            }
+
+            // Map configured fields to their display labels and order.
+            const countsByField = {};
+            for (const fc of facetCounts) {
+                countsByField[fc.field_name] = fc.counts || [];
+            }
+
+            const groups = this.config.facets.map(facet => {
+                const counts = countsByField[facet.field] || [];
+                if (counts.length === 0) return '';
+
+                const selected = this.selectedFacets[facet.field];
+                const chips = counts.map(({ value, count }) => {
+                    const isSelected = selected ? selected.has(value) : false;
+                    const safeValue = this.escapeHtmlAttr(value);
+                    return `
+                        <button type="button"
+                            class="${CSS_PREFIX}-facet-chip${isSelected ? ` ${CSS_PREFIX}-facet-chip-selected` : ''}"
+                            data-facet-field="${this.escapeHtmlAttr(facet.field)}"
+                            data-facet-value="${safeValue}"
+                            aria-pressed="${isSelected ? 'true' : 'false'}">
+                            <span class="${CSS_PREFIX}-facet-chip-label">${safeValue}</span>
+                            <span class="${CSS_PREFIX}-facet-chip-count">${count}</span>
+                        </button>
+                    `;
+                }).join('');
+
+                return `
+                    <div class="${CSS_PREFIX}-facet-group">
+                        <div class="${CSS_PREFIX}-facet-group-label">${this.escapeHtmlAttr(facet.label || facet.field)}</div>
+                        <div class="${CSS_PREFIX}-facet-chips" role="list">${chips}</div>
+                    </div>
+                `;
+            }).join('');
+
+            const hasSelection = Object.values(this.selectedFacets).some(s => s && s.size > 0);
+            const clearButton = hasSelection
+                ? `<button type="button" class="${CSS_PREFIX}-facet-clear">${this.t('clearFiltersLabel')}</button>`
+                : '';
+
+            this.facetsContainer.innerHTML = groups + clearButton;
+            this.facetsContainer.classList.toggle(`${CSS_PREFIX}-hidden`, groups.trim() === '');
+        }
+
+        // Delegated handler for facet chip toggles and the clear-filters
+        // button. Toggling a value updates the selection and re-runs the
+        // current query so results and counts reflect the active filters.
+        attachFacetListeners() {
+            if (!this.facetsContainer) return;
+
+            this.facetsContainer.addEventListener('click', (e) => {
+                const clearBtn = e.target.closest(`.${CSS_PREFIX}-facet-clear`);
+                if (clearBtn) {
+                    e.preventDefault();
+                    this.selectedFacets = {};
+                    this.rerunQueryForFacets();
+                    return;
+                }
+
+                const chip = e.target.closest(`.${CSS_PREFIX}-facet-chip`);
+                if (!chip) return;
+                e.preventDefault();
+
+                const field = chip.dataset.facetField;
+                const value = chip.dataset.facetValue;
+                if (!field || value === undefined) return;
+
+                if (!this.selectedFacets[field]) {
+                    this.selectedFacets[field] = new Set();
+                }
+                const set = this.selectedFacets[field];
+                if (set.has(value)) {
+                    set.delete(value);
+                } else {
+                    set.add(value);
+                }
+
+                this.rerunQueryForFacets();
+            });
+        }
+
+        // Re-run the active query after a facet change, using the live input
+        // value (falling back to the last searched query).
+        rerunQueryForFacets() {
+            const query = this.searchInput?.value?.trim() || this.lastQuery;
+            if (query) {
+                this.handleSearch(query);
+            }
         }
 
         handleKeydown(e) {

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -376,6 +376,85 @@
     border-color: var(--accent-color);
 }
 
+/* Reader-facing facet filters */
+.mp-search-facets {
+    display: flex;
+    flex-direction: column;
+    gap: calc(0.75 * var(--mp-rem));
+    padding: calc(0.75 * var(--mp-rem)) 0;
+}
+
+.mp-search-facet-group {
+    display: flex;
+    flex-direction: column;
+    gap: calc(0.5 * var(--mp-rem));
+}
+
+.mp-search-facet-group-label {
+    color: var(--color-text-secondary);
+    font-size: calc(0.75 * var(--mp-rem));
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.mp-search-facet-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(0.5 * var(--mp-rem));
+}
+
+.mp-search-facet-chip {
+    background: transparent;
+    border: 1px solid var(--color-border, var(--color-result-hover));
+    color: var(--color-text);
+    border-radius: 999px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: calc(0.375 * var(--mp-rem));
+    padding: calc(0.375 * var(--mp-rem)) calc(0.75 * var(--mp-rem));
+    font-size: calc(0.8125 * var(--mp-rem));
+    line-height: 1.2;
+    transition: all var(--transition-base);
+}
+
+.mp-search-facet-chip:hover,
+.mp-search-facet-chip:focus-visible {
+    background: var(--color-result-hover);
+    border-color: var(--accent-color);
+}
+
+.mp-search-facet-chip-selected,
+.mp-search-facet-chip[aria-pressed="true"] {
+    background: var(--accent-color);
+    border-color: var(--accent-color);
+    color: #fff;
+}
+
+.mp-search-facet-chip-count {
+    font-size: calc(0.6875 * var(--mp-rem));
+    font-variant-numeric: tabular-nums;
+    opacity: 0.7;
+}
+
+.mp-search-facet-clear {
+    align-self: flex-start;
+    background: transparent;
+    border: none;
+    color: var(--accent-color);
+    cursor: pointer;
+    font-size: calc(0.8125 * var(--mp-rem));
+    padding: calc(0.25 * var(--mp-rem)) 0;
+    text-decoration: underline;
+    transition: opacity var(--transition-base);
+}
+
+.mp-search-facet-clear:hover,
+.mp-search-facet-clear:focus-visible {
+    opacity: 0.7;
+}
+
 .mp-search-hits-list {
     margin-block-start: calc(0.5 * var(--mp-rem));
     margin-block-end: calc(0.5 * var(--mp-rem));


### PR DESCRIPTION
## Summary

Adds optional reader-facing **facet filters** to the search modal. The collection already facets `tags`, `tags.name`, `tags.slug`, and `authors` — this exposes them as selectable chips so readers can narrow results, not just publishers via `filter_by`.

- New `facets` config: `[{ field, label?, limit? }]`. When set, the widget requests `facet_by` counts alongside results and renders each field as a row of chips with **live counts**.
- Selecting values filters results and refreshes counts. Values within a field are **OR**-ed; different fields are **AND**-ed.
- Selections clear individually (toggle a chip) or all at once (**Clear filters** button), and reset on modal close.
- A publisher-provided `typesenseSearchParams.filter_by` is **preserved** — facet selections are AND-ed with it (both sides parenthesised), never overwritten.
- Facet values are backtick-quoted in the `filter_by` expression and HTML-escaped in the markup (they come from indexed content).
- Chips are `<button aria-pressed>` styled inside the Shadow DOM, so they're keyboard-focusable and toggle with Enter/Space.

With no `facets` config, the UI and queries are unchanged (the container is `display:none` and empty; no `facet_by`/`filter_by` is added).

## Acceptance criteria

- [x] No `facets` config → UI and queries unchanged
- [x] Configured facets render with live counts and are selectable
- [x] Selecting filters results and updates counts; clearing restores the unfiltered query
- [x] Publisher `filter_by` preserved and combined, not overwritten
- [x] Facet controls keyboard-accessible and styled within the Shadow DOM
- [x] README documents the `facets` config and its `filter_by` interaction

## Test plan

- [x] \`npm run lint\` (5/5) and full \`turbo lint build\` (10/10)
- [x] \`npm run build\` — facet logic + CSS confirmed in the bundle
- [ ] Manual: configure \`facets\`, run a query → chips render with counts; selecting filters results and updates counts; multi-select OR-s within a field; a configured \`filter_by\` is still respected; Clear filters resets; chips reachable/toggleable by keyboard

> Note: \`packages/search-ui\` has no unit-test runner (\`test\` is \`exit 0\`), so this is verified via lint + build + manual trace, consistent with the prior search-ui PRs.

close #16