### PR TITLE
test: add Vitest + jsdom test suite for the search UI (close #27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "1.11.3",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -31,11 +31,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "1.11.3",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^1.11.3",
-        "@magicpages/ghost-typesense-core": "^1.11.3",
+        "@magicpages/ghost-typesense-config": "^1.12.0",
+        "@magicpages/ghost-typesense-core": "^1.12.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ora": "^8.0.1"
@@ -133,11 +133,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "1.11.3",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^1.11.3",
-        "@magicpages/ghost-typesense-core": "^1.11.3",
+        "@magicpages/ghost-typesense-config": "^1.12.0",
+        "@magicpages/ghost-typesense-core": "^1.12.0",
         "@netlify/functions": "^2.5.1",
         "zod": "^3.22.4"
       },
@@ -224,6 +224,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -237,6 +251,121 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -1891,6 +2020,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
       "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "0.34.6",
         "@vitest/utils": "0.34.6",
@@ -1904,6 +2034,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
       "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "0.34.6",
         "p-limit": "^4.0.0",
@@ -1917,6 +2048,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
       "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
+      "peer": true,
       "dependencies": {
         "magic-string": "^0.30.1",
         "pathe": "^1.1.1",
@@ -1930,6 +2062,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
       "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
+      "peer": true,
       "dependencies": {
         "tinyspy": "^2.1.1"
       },
@@ -1941,6 +2074,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
       "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
+      "peer": true,
       "dependencies": {
         "diff-sequences": "^29.4.3",
         "loupe": "^2.3.6",
@@ -1954,6 +2088,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
       "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -1965,6 +2100,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -1978,12 +2114,14 @@
     "node_modules/@ts-ghost/core-api/node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "peer": true
     },
     "node_modules/@ts-ghost/core-api/node_modules/strip-literal": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
       "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.10.0"
       },
@@ -1995,6 +2133,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
       "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2003,6 +2142,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
       "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
+      "peer": true,
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -2102,6 +2242,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
       "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -2119,6 +2260,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz",
       "integrity": "sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==",
+      "peer": true,
       "peerDependencies": {
         "@types/chai": "<5.2.0"
       }
@@ -2199,7 +2341,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2477,7 +2618,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2503,6 +2643,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2647,7 +2797,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3226,6 +3375,78 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3241,6 +3462,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -3473,7 +3701,6 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3535,7 +3762,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4190,10 +4416,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -4440,6 +4707,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -4570,6 +4844,84 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/json-buffer": {
@@ -4763,7 +5115,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5030,6 +5382,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5257,6 +5616,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5391,7 +5776,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6031,14 +6415,34 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6094,6 +6498,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -6935,6 +7346,13 @@
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -7006,7 +7424,20 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -7328,12 +7759,18 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -7462,7 +7899,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7497,6 +7933,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -7781,7 +8233,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7794,7 +8245,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.8.2.tgz",
       "integrity": "sha512-aBpePjA99Qvo+OP2pJwMpvga4Jrm1Y2oV5NsrWXBxlqUDNEUCPZBIksPv2Hq0jxQxHhLLyJVbjXjByXsvpCDVA==",
-      "peer": true,
       "dependencies": {
         "axios": "^1.6.0",
         "loglevel": "^1.8.1"
@@ -7815,6 +8265,16 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -7853,6 +8313,17 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -8418,10 +8889,60 @@
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -8507,6 +9028,45 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8584,7 +9144,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "1.11.3",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -8666,10 +9226,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "1.11.3",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^1.11.3",
+        "@magicpages/ghost-typesense-config": "^1.12.0",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "typesense": "^1.7.2",
@@ -8748,7 +9308,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "1.11.3",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -8760,12 +9320,14 @@
         "@rollup/plugin-terser": "^0.4.4",
         "cssnano": "^6.0.3",
         "eslint": "^8.56.0",
+        "jsdom": "^24.0.0",
         "postcss": "^8.4.35",
         "prettier": "^3.2.5",
         "rimraf": "^5.0.5",
         "rollup": "^4.12.0",
         "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-visualizer": "^5.14.0"
+        "rollup-plugin-visualizer": "^5.14.0",
+        "vitest": "^1.2.2"
       }
     },
     "packages/search-ui/node_modules/foreground-child": {
@@ -8842,6 +9404,19 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "devOptional": true,
+      "requires": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
     "@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -8852,6 +9427,42 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "devOptional": true
+    },
+    "@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "devOptional": true,
+      "requires": {}
+    },
+    "@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "devOptional": true,
+      "requires": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      }
+    },
+    "@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "devOptional": true,
+      "requires": {}
+    },
+    "@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "devOptional": true
     },
     "@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -9432,8 +10043,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^1.11.3",
-        "@magicpages/ghost-typesense-core": "^1.11.3",
+        "@magicpages/ghost-typesense-config": "^1.12.0",
+        "@magicpages/ghost-typesense-core": "^1.12.0",
         "@types/node": "^20.11.17",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -9540,7 +10151,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^1.11.3",
+        "@magicpages/ghost-typesense-config": "^1.12.0",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "@types/node": "^20.11.17",
@@ -9599,13 +10210,15 @@
         "@rollup/plugin-terser": "^0.4.4",
         "cssnano": "^6.0.3",
         "eslint": "^8.56.0",
+        "jsdom": "^24.0.0",
         "postcss": "^8.4.35",
         "prettier": "^3.2.5",
         "rimraf": "^5.0.5",
         "rollup": "^4.12.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-visualizer": "^5.14.0",
-        "typesense": "^1.7.2"
+        "typesense": "^1.7.2",
+        "vitest": "^1.2.2"
       },
       "dependencies": {
         "foreground-child": {
@@ -9649,8 +10262,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^1.11.3",
-        "@magicpages/ghost-typesense-core": "^1.11.3",
+        "@magicpages/ghost-typesense-config": "^1.12.0",
+        "@magicpages/ghost-typesense-core": "^1.12.0",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^20.11.17",
         "rimraf": "^5.0.5",
@@ -10053,6 +10666,7 @@
           "version": "0.34.6",
           "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
           "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
+          "peer": true,
           "requires": {
             "@vitest/spy": "0.34.6",
             "@vitest/utils": "0.34.6",
@@ -10063,6 +10677,7 @@
           "version": "0.34.6",
           "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
           "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
+          "peer": true,
           "requires": {
             "@vitest/utils": "0.34.6",
             "p-limit": "^4.0.0",
@@ -10073,6 +10688,7 @@
           "version": "0.34.6",
           "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
           "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
+          "peer": true,
           "requires": {
             "magic-string": "^0.30.1",
             "pathe": "^1.1.1",
@@ -10083,6 +10699,7 @@
           "version": "0.34.6",
           "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
           "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
+          "peer": true,
           "requires": {
             "tinyspy": "^2.1.1"
           }
@@ -10091,6 +10708,7 @@
           "version": "0.34.6",
           "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
           "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
+          "peer": true,
           "requires": {
             "diff-sequences": "^29.4.3",
             "loupe": "^2.3.6",
@@ -10100,12 +10718,14 @@
         "local-pkg": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
-          "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g=="
+          "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+          "peer": true
         },
         "p-limit": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
           "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+          "peer": true,
           "requires": {
             "yocto-queue": "^1.0.0"
           }
@@ -10113,12 +10733,14 @@
         "pathe": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-          "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+          "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+          "peer": true
         },
         "strip-literal": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
           "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+          "peer": true,
           "requires": {
             "acorn": "^8.10.0"
           }
@@ -10126,12 +10748,14 @@
         "tinypool": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
-          "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww=="
+          "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
+          "peer": true
         },
         "vite-node": {
           "version": "0.34.6",
           "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
           "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
+          "peer": true,
           "requires": {
             "cac": "^6.7.14",
             "debug": "^4.3.4",
@@ -10176,7 +10800,8 @@
         "yocto-queue": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-          "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="
+          "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+          "peer": true
         }
       }
     },
@@ -10190,6 +10815,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz",
       "integrity": "sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==",
+      "peer": true,
       "requires": {}
     },
     "@types/estree": {
@@ -10252,7 +10878,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -10435,8 +11060,7 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -10452,6 +11076,12 @@
       "requires": {
         "acorn": "^8.11.0"
       }
+    },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "devOptional": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -10556,7 +11186,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10979,6 +11608,61 @@
         }
       }
     },
+    "cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "devOptional": true,
+      "requires": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "dependencies": {
+        "rrweb-cssom": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+          "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+          "devOptional": true
+        }
+      }
+    },
+    "data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "devOptional": true,
+      "requires": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+          "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+          "devOptional": true,
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "devOptional": true
+        },
+        "whatwg-url": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+          "devOptional": true,
+          "requires": {
+            "tr46": "^5.1.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -10986,6 +11670,12 @@
       "requires": {
         "ms": "^2.1.3"
       }
+    },
+    "decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "devOptional": true
     },
     "deep-eql": {
       "version": "4.1.4",
@@ -11151,7 +11841,6 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@esbuild/aix-ppc64": "0.27.2",
         "@esbuild/android-arm": "0.27.2",
@@ -11197,7 +11886,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11676,10 +12364,39 @@
         "function-bind": "^1.1.2"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "devOptional": true,
+      "requires": {
+        "whatwg-encoding": "^3.1.1"
+      }
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+    },
+    "http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "devOptional": true,
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "devOptional": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      }
     },
     "human-signals": {
       "version": "5.0.0",
@@ -11844,6 +12561,12 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "devOptional": true
+    },
     "is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -11936,6 +12659,62 @@
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
+      }
+    },
+    "jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "devOptional": true,
+      "requires": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+          "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+          "devOptional": true,
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "devOptional": true
+        },
+        "whatwg-url": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+          "devOptional": true,
+          "requires": {
+            "tr46": "^5.1.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "json-buffer": {
@@ -12079,7 +12858,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "devOptional": true
     },
     "magic-string": {
       "version": "0.30.21",
@@ -12259,6 +13038,12 @@
         "boolbase": "^1.0.0"
       }
     },
+    "nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "devOptional": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12413,6 +13198,23 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "devOptional": true,
+      "requires": {
+        "entities": "^6.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+          "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+          "devOptional": true
+        }
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12497,7 +13299,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12904,11 +13705,26 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "devOptional": true,
+      "requires": {
+        "punycode": "^2.3.1"
+      }
+    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true
+      "devOptional": true
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "devOptional": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -12940,6 +13756,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "devOptional": true
     },
     "resolve": {
       "version": "1.22.11",
@@ -13497,6 +14319,12 @@
         }
       }
     },
+    "rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "devOptional": true
+    },
     "run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -13537,7 +14365,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
+    },
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "semver": {
       "version": "7.7.3",
@@ -13763,12 +14600,17 @@
         "picocolors": "^1.0.0"
       }
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "devOptional": true
+    },
     "terser": {
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -13869,8 +14711,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -13892,6 +14733,18 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "devOptional": true,
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       }
     },
     "tr46": {
@@ -14052,14 +14905,12 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "typesense": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.8.2.tgz",
       "integrity": "sha512-aBpePjA99Qvo+OP2pJwMpvga4Jrm1Y2oV5NsrWXBxlqUDNEUCPZBIksPv2Hq0jxQxHhLLyJVbjXjByXsvpCDVA==",
-      "peer": true,
       "requires": {
         "axios": "^1.6.0",
         "loglevel": "^1.8.1"
@@ -14074,6 +14925,12 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "devOptional": true
     },
     "update-browserslist-db": {
       "version": "1.2.3",
@@ -14092,6 +14949,16 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "devOptional": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "urlpattern-polyfill": {
@@ -14353,10 +15220,45 @@
         }
       }
     },
+    "w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
+      "requires": {
+        "xml-name-validator": "^5.0.0"
+      }
+    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "devOptional": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "devOptional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "devOptional": true
     },
     "whatwg-url": {
       "version": "5.0.0",
@@ -14416,6 +15318,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
+      "requires": {}
+    },
+    "xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "devOptional": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -484,6 +484,20 @@ i18n: {
 }
 ```
 
+## Development
+
+Tests run on [Vitest](https://vitest.dev/) with a jsdom environment (the widget
+is a browser Web Component):
+
+```bash
+npm test            # from packages/search-ui, or `npm test` at the repo root
+```
+
+The suite lives in `src/__tests__/` and covers the search-parameter building,
+analytics, suggestion, and facet logic. **Changes to the search UI should ship
+with tests** for the behavior they add or change, matching the other packages in
+this monorepo.
+
 ## License
 
 MIT © [MagicPages](https://www.magicpages.co)

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "exit 0",
+    "test": "vitest run",
     "lint": "eslint src/**/*.js",
     "format": "prettier --write src/**/*.{js,css}",
     "clean": "rimraf dist"
@@ -43,7 +43,9 @@
     "rimraf": "^5.0.5",
     "rollup": "^4.12.0",
     "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-visualizer": "^5.14.0"
+    "rollup-plugin-visualizer": "^5.14.0",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '../search.js';
+
+// Build an element with shadow content rendered, but without going through
+// connectedCallback (whose one-time `isInitialized` guard would block repeated
+// construction). We set config explicitly and run the same setup steps init()
+// would: render the shadow DOM and cache element references.
+function mountWithConfig(config = {}) {
+  const el = document.createElement('magicpages-search');
+  el.config = {
+    typesenseNodes: [{ host: 'localhost', port: '8108', protocol: 'http' }],
+    typesenseApiKey: 'search-only',
+    collectionName: 'ghost',
+    commonSearches: [],
+    pinnedSearches: [],
+    facets: [],
+    enableHighlighting: true,
+    searchFields: {
+      title: { weight: 5, highlight: true },
+      excerpt: { weight: 3, highlight: true },
+      plaintext: { weight: 4, highlight: true }
+    },
+    ...config
+  };
+  el.i18n = el.defaultI18n;
+  el.selectedFacets = {};
+  el.fetchedSuggestions = [];
+  el.createShadowContent();
+  el.cacheElements();
+  return el;
+}
+
+describe('getSearchParameters — lexical baseline', () => {
+  it('produces the default lexical query with no opt-in features configured', () => {
+    const el = mountWithConfig();
+    const params = el.getSearchParameters();
+
+    expect(params.query_by).toBe('title,excerpt,plaintext');
+    expect(params.facet_by).toBeUndefined();
+    expect(params.filter_by).toBeUndefined();
+    expect(params.per_page).toBe(20);
+  });
+});
+
+describe('getSearchParameters — facets', () => {
+  const facetConfig = {
+    facets: [
+      { field: 'tags.name', label: 'Topics', limit: 10 },
+      { field: 'authors', label: 'Authors', limit: 5 }
+    ]
+  };
+
+  it('requests facet_by for the configured fields', () => {
+    const el = mountWithConfig(facetConfig);
+    expect(el.getSearchParameters().facet_by).toBe('tags.name,authors');
+  });
+
+  it('composes selected facets into filter_by, preserving a publisher filter', () => {
+    const el = mountWithConfig({
+      ...facetConfig,
+      typesenseSearchParams: { filter_by: 'published_at:>0' }
+    });
+    el.selectedFacets = { 'tags.name': new Set(['Ghost']) };
+
+    expect(el.getSearchParameters().filter_by).toBe('(published_at:>0) && (tags.name:=[`Ghost`])');
+  });
+
+  it('omits filter_by entirely when no facet is selected and no publisher filter is set', () => {
+    const el = mountWithConfig(facetConfig);
+    expect(el.getSearchParameters().filter_by).toBeUndefined();
+  });
+});
+
+describe('getSearchParameters — analytics include_fields', () => {
+  it('re-adds id to include_fields when analytics is enabled and a host omitted it', () => {
+    const el = mountWithConfig({
+      analytics: { endpoint: 'https://example.com/collect' },
+      typesenseSearchParams: { include_fields: 'title,url' }
+    });
+    const fields = el.getSearchParameters().include_fields.split(',');
+    expect(fields).toContain('id');
+  });
+
+  it('does not touch include_fields when analytics is disabled', () => {
+    const el = mountWithConfig({
+      typesenseSearchParams: { include_fields: 'title,url' }
+    });
+    expect(el.getSearchParameters().include_fields).toBe('title,url');
+  });
+});
+
+describe('analytics events', () => {
+  let beacon;
+  beforeEach(() => {
+    beacon = vi.fn(() => true);
+    navigator.sendBeacon = beacon;
+  });
+
+  it('emits one search event for a settled query and dedupes a repeat', () => {
+    const el = mountWithConfig({ analytics: { endpoint: 'https://e/collect', siteId: 's' } });
+
+    el.trackSearch('ghost', 3);
+    el.trackSearch('ghost', 3); // same query → suppressed by lastTrackedQuery
+    el.trackSearch('themes', 0); // new query, zero results → search + zero_result
+
+    // ghost(search) + themes(search) + themes(zero_result) = 3 beacons; the
+    // repeated "ghost" call emits nothing.
+    expect(beacon).toHaveBeenCalledTimes(3);
+  });
+
+  it('emits nothing when analytics is not configured', () => {
+    const el = mountWithConfig();
+    el.trackSearch('ghost', 3);
+    expect(beacon).not.toHaveBeenCalled();
+  });
+});
+
+describe('suggestions fetching', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a bare string array from suggestionsUrl', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ['alpha', 'beta']
+    });
+    const el = mountWithConfig({ suggestionsUrl: 'https://e/suggest' });
+    await el.fetchSuggestions();
+    expect(el.fetchedSuggestions).toEqual(['alpha', 'beta']);
+  });
+
+  it('accepts a { suggestions: [...] } object', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ suggestions: ['gamma'] })
+    });
+    const el = mountWithConfig({ suggestionsUrl: 'https://e/suggest' });
+    await el.fetchSuggestions();
+    expect(el.fetchedSuggestions).toEqual(['gamma']);
+  });
+
+  it('falls back silently on a failed fetch and does not retry within the session', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+    global.fetch = fetchMock;
+    const el = mountWithConfig({
+      suggestionsUrl: 'https://e/suggest',
+      commonSearches: ['fallback']
+    });
+
+    await el.fetchSuggestions();
+    expect(el.fetchedSuggestions).toEqual([]);
+    expect(el.getSuggestions()).toEqual(['fallback']);
+
+    await el.fetchSuggestions(); // session cache: no second request
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch when no suggestionsUrl is configured', async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    const el = mountWithConfig();
+    await el.fetchSuggestions();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('facet rendering', () => {
+  it('renders chips with counts and marks selected values aria-pressed', () => {
+    const el = mountWithConfig({
+      facets: [{ field: 'tags.name', label: 'Topics' }]
+    });
+    el.selectedFacets = { 'tags.name': new Set(['Ghost']) };
+
+    el.renderFacets([
+      { field_name: 'tags.name', counts: [
+        { value: 'Ghost', count: 4 },
+        { value: 'Themes', count: 2 }
+      ] }
+    ]);
+
+    const chips = el.facetsContainer.querySelectorAll('.mp-search-facet-chip');
+    expect(chips).toHaveLength(2);
+
+    const ghost = [...chips].find(c => c.dataset.facetValue === 'Ghost');
+    expect(ghost.getAttribute('aria-pressed')).toBe('true');
+    expect(ghost.querySelector('.mp-search-facet-chip-count').textContent).toBe('4');
+
+    const themes = [...chips].find(c => c.dataset.facetValue === 'Themes');
+    expect(themes.getAttribute('aria-pressed')).toBe('false');
+
+    // A clear-all control appears when something is selected.
+    expect(el.facetsContainer.querySelector('.mp-search-facet-clear')).not.toBeNull();
+  });
+
+  it('hides the facet container when no counts are returned', () => {
+    const el = mountWithConfig({ facets: [{ field: 'tags.name' }] });
+    el.renderFacets([]);
+    expect(el.facetsContainer.classList.contains('mp-search-hidden')).toBe(true);
+  });
+});

--- a/packages/search-ui/src/__tests__/helpers.test.js
+++ b/packages/search-ui/src/__tests__/helpers.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../search.js';
+
+// The component class is only exposed via window (search.js is an IIFE with no
+// exports). Construct instances through the registered element so the custom
+// element upgrade runs the constructor, then drive the pure methods directly
+// with an explicit config — this avoids connectedCallback's one-time
+// `isInitialized` guard, which would otherwise block a second instance.
+function makeInstance(config = {}) {
+  const el = document.createElement('magicpages-search');
+  el.config = {
+    typesenseNodes: [{ host: 'localhost', port: '8108', protocol: 'http' }],
+    typesenseApiKey: 'search-only',
+    collectionName: 'ghost',
+    commonSearches: [],
+    pinnedSearches: [],
+    facets: [],
+    searchFields: {
+      title: { weight: 5, highlight: true },
+      excerpt: { weight: 3, highlight: true },
+      plaintext: { weight: 4, highlight: true }
+    },
+    ...config
+  };
+  el.i18n = el.defaultI18n;
+  el.selectedFacets = {};
+  el.fetchedSuggestions = [];
+  return el;
+}
+
+describe('escapeHtmlAttr', () => {
+  const el = makeInstance();
+
+  it('escapes the five significant characters', () => {
+    expect(el.escapeHtmlAttr(`& < > " '`)).toBe('&amp; &lt; &gt; &quot; &#39;');
+  });
+
+  it('coerces null/undefined to an empty string', () => {
+    expect(el.escapeHtmlAttr(undefined)).toBe('');
+    expect(el.escapeHtmlAttr(null)).toBe('');
+  });
+
+  it('escapes ampersand before entities to avoid double-encoding artifacts', () => {
+    expect(el.escapeHtmlAttr('a&b<c')).toBe('a&amp;b&lt;c');
+  });
+});
+
+describe('toRelativeUrl', () => {
+  const el = makeInstance();
+
+  it('strips the origin, keeping path, search and hash', () => {
+    expect(el.toRelativeUrl('https://example.com/blog/post/?a=1#x')).toBe('/blog/post/?a=1#x');
+  });
+
+  it('returns # for an empty value and the original for an unparseable one', () => {
+    expect(el.toRelativeUrl('')).toBe('#');
+    expect(el.toRelativeUrl('not a url')).toBe('not a url');
+  });
+});
+
+describe('getSuggestions', () => {
+  it('orders pinned first, then fetched, then commonSearches', () => {
+    const el = makeInstance({
+      pinnedSearches: ['Pinned'],
+      commonSearches: ['Common']
+    });
+    el.fetchedSuggestions = ['Fetched'];
+    expect(el.getSuggestions()).toEqual(['Pinned', 'Fetched', 'Common']);
+  });
+
+  it('collapses duplicates case-insensitively, keeping the first occurrence', () => {
+    const el = makeInstance({
+      pinnedSearches: ['Tutorials'],
+      commonSearches: ['tutorials', 'Pricing']
+    });
+    el.fetchedSuggestions = ['TUTORIALS'];
+    expect(el.getSuggestions()).toEqual(['Tutorials', 'Pricing']);
+  });
+
+  it('ignores non-strings and blank entries', () => {
+    const el = makeInstance({ commonSearches: ['  ', 'Real', 42, null] });
+    expect(el.getSuggestions()).toEqual(['Real']);
+  });
+});
+
+describe('facet filter composition', () => {
+  let el;
+  beforeEach(() => {
+    el = makeInstance({
+      facets: [
+        { field: 'tags.name', label: 'Topics' },
+        { field: 'authors', label: 'Authors' }
+      ]
+    });
+  });
+
+  it('returns an empty clause when nothing is selected', () => {
+    expect(el.buildFacetFilter()).toBe('');
+  });
+
+  it('ORs values within a field and ANDs across fields, backtick-quoting values', () => {
+    el.selectedFacets = {
+      'tags.name': new Set(['Ghost', 'How To']),
+      authors: new Set(['Jannis'])
+    };
+    expect(el.buildFacetFilter()).toBe('tags.name:=[`Ghost`,`How To`] && authors:=[`Jannis`]');
+  });
+
+  it('strips backticks from values so they cannot break the expression', () => {
+    el.selectedFacets = { 'tags.name': new Set(['a`b']) };
+    expect(el.buildFacetFilter()).toBe('tags.name:=[`ab`]');
+  });
+
+  it('preserves a publisher filter by ANDing it with the facet clause', () => {
+    el.selectedFacets = { authors: new Set(['Jannis']) };
+    expect(el.composeFilterBy('published_at:>0')).toBe('(published_at:>0) && (authors:=[`Jannis`])');
+  });
+
+  it('returns the publisher filter unchanged when no facets are selected', () => {
+    expect(el.composeFilterBy('published_at:>0')).toBe('published_at:>0');
+  });
+
+  it('returns only the facet clause when there is no publisher filter', () => {
+    el.selectedFacets = { authors: new Set(['Jannis']) };
+    expect(el.composeFilterBy(undefined)).toBe('authors:=[`Jannis`]');
+  });
+});

--- a/packages/search-ui/src/__tests__/setup.js
+++ b/packages/search-ui/src/__tests__/setup.js
@@ -1,0 +1,12 @@
+// Test setup for the search UI suite.
+//
+// `search.js` is bundled by Rollup with a `const BUNDLED_CSS = "..."` banner
+// injected at build time, and reads that global when an element renders its
+// shadow DOM. Under Vitest the banner is absent, so define the global before
+// the module is imported, otherwise the source throws on first render.
+globalThis.BUNDLED_CSS = '';
+
+// Keep auto-initialization inert: search.js creates a default element on load
+// only when a global config (or a search hash/param) is present. Tests
+// construct their own elements with explicit config, so leave this unset.
+delete globalThis.__MP_SEARCH_CONFIG__;

--- a/packages/search-ui/vitest.config.js
+++ b/packages/search-ui/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // search.js is a browser Web Component (document, customElements, Shadow
+    // DOM, matchMedia, sendBeacon), so it needs a DOM environment.
+    environment: 'jsdom',
+    setupFiles: ['./src/__tests__/setup.js'],
+    include: ['src/__tests__/**/*.test.js']
+  }
+});


### PR DESCRIPTION
## Summary

`packages/search-ui` was the only package without a real test runner — its test script was `"exit 0"`. This adds **Vitest with a jsdom environment** and a suite covering the logic that accumulated in `search.js` (analytics, suggestions, facets), which until now was verified only by lint + build + manual review.

- Replaces `"test": "exit 0"` with `"test": "vitest run"`. The existing `test` Turbo task picks it up — `turbo run test` now runs **10/10** packages, no pipeline change.
- `search.js` is **untouched**. It's an IIFE with no exports, so tests import it for its side effects and reach the component via `window.MagicPagesSearch`. A setup file defines the `BUNDLED_CSS` global that Rollup normally injects as a banner. The Typesense client and `fetch`/`sendBeacon` are stubbed; everything between config and the resulting query params / DOM is the real code.
- jsdom is needed because the widget is a browser Web Component (Shadow DOM, `customElements`, `matchMedia`, `sendBeacon`).

## Coverage (28 tests)

- **Pure helpers:** `escapeHtmlAttr`, `toRelativeUrl`, suggestion resolution + case-insensitive de-dup, `buildFacetFilter`/`composeFilterBy` (OR within field, AND across, backtick-stripping, publisher-filter preservation).
- **Analytics:** settled-query de-duplication and the no-config no-op.
- **Suggestions:** both response shapes (`string[]` and `{ suggestions }`), fail-silent fallback, session caching (no re-fetch), and no-fetch-without-URL.
- **Facets:** `facet_by` wiring, `filter_by` composition preserving a publisher filter, chip rendering with counts + `aria-pressed`, and hide-when-empty.
- **Baseline:** with no opt-in features, the query is the plain lexical default (no `facet_by`/`filter_by`).

## Going forward

Per #27, the README now states that search-ui changes should ship with tests, matching the other packages.

## Test plan

- [x] `npm test` in `packages/search-ui` → 28/28
- [x] `npm run lint` (5/5; test files lint clean)
- [x] `npm test` at root → `turbo` 10/10 including search-ui
- [x] `npm run build` (5/5)
- [x] Fresh (uncached) `turbo run test --force` → 28/28

close #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * README expanded with Development section documenting how to run the test suite and identifying key test coverage areas for contributors.

* **Tests**
  * New comprehensive test suite added covering parameter building, analytics behavior, suggestions functionality, and facet filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->