### PR TITLE
feat: add a grid (card) result template (close #17)

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -94,6 +94,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `semanticSearch` | `Boolean` | No | `false` | Enable hybrid (keyword + vector) search against an embedding field (see [Semantic search](#semantic-search)) |
 | `embeddingFieldName` | `String` | No | `'embedding'` | Name of the collection's embedding field, used when `semanticSearch` is enabled |
 | `facets` | `Array` | No | `[]` | Reader-facing filter controls for faceted fields (see [Filters](#filters)) |
+| `template` | `String` | No | `'list'` | Result layout: `'list'` or `'grid'` (see [Result templates](#result-templates)) |
 
 ### Search Fields Configuration
 
@@ -233,6 +234,22 @@ The endpoint may return either a bare array of strings or an object with a `sugg
 ```
 
 The fetch is **fail-silent**: if the request errors or returns a non-success status, the widget falls back to `pinnedSearches` + `commonSearches` with no visible error, and does not retry that URL for the rest of the session. The widget is backend-agnostic — it only consumes the URL and does not define where the suggestions come from.
+
+## Result templates
+
+Results render as a vertical **list** by default. Image-led publications can switch to a **grid** of cards that feature each post's image:
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    template: 'grid' // 'list' (default) | 'grid'
+};
+```
+
+- `'list'` — the default title-and-excerpt rows.
+- `'grid'` — responsive cards (multi-column on desktop, single column on mobile) showing the post's `feature_image`, title, excerpt, and up to three tags. Posts without a feature image get a styled placeholder rather than a broken image.
+
+Both layouts use the same results, highlighting, keyboard navigation, and click handling — only the markup differs. The grid layout adds `feature_image` to the requested fields; the list layout's query is unchanged.
 
 ## Filters
 

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -199,3 +199,70 @@ describe('facet rendering', () => {
     expect(el.facetsContainer.classList.contains('mp-search-hidden')).toBe(true);
   });
 });
+
+// Parse a markup string into an element for structural assertions.
+function parse(html) {
+  const wrap = document.createElement('div');
+  wrap.innerHTML = html;
+  return wrap;
+}
+
+describe('result templates', () => {
+  it('renders the list item with a title and excerpt (default layout)', () => {
+    const el = mountWithConfig();
+    const dom = parse(el.renderListItem('My title', 'An excerpt'));
+
+    expect(dom.querySelector('.mp-search-result-title').textContent).toContain('My title');
+    expect(dom.querySelector('.mp-search-result-excerpt').textContent).toContain('An excerpt');
+    // No card-specific markup in list mode.
+    expect(dom.querySelector('.mp-search-card-image')).toBeNull();
+  });
+
+  it('renders a grid card with image, title, excerpt and tags', () => {
+    const el = mountWithConfig({ template: 'grid' });
+    const hit = {
+      document: {
+        id: 'p1',
+        title: 'Tomatoes',
+        feature_image: 'https://cdn.example.com/t.jpg',
+        tags: ['Garden', 'How To', 'Spring', 'Extra']
+      }
+    };
+    const dom = parse(el.renderGridCard(hit, 'Tomatoes', 'Grow them'));
+
+    const img = dom.querySelector('img.mp-search-card-image');
+    expect(img.getAttribute('src')).toBe('https://cdn.example.com/t.jpg');
+    expect(img.getAttribute('alt')).toBe(''); // decorative; link carries the label
+    expect(dom.querySelector('.mp-search-result-title').textContent).toContain('Tomatoes');
+    expect(dom.querySelector('.mp-search-result-excerpt').textContent).toContain('Grow them');
+
+    // Tags are capped at three.
+    const tags = dom.querySelectorAll('.mp-search-card-tag');
+    expect([...tags].map(t => t.textContent)).toEqual(['Garden', 'How To', 'Spring']);
+  });
+
+  it('shows a placeholder instead of a broken image when feature_image is absent', () => {
+    const el = mountWithConfig({ template: 'grid' });
+    const dom = parse(el.renderGridCard({ document: { id: 'p1', tags: [] } }, 'Untitled', ''));
+
+    expect(dom.querySelector('img.mp-search-card-image')).toBeNull();
+    expect(dom.querySelector('.mp-search-card-image-empty')).not.toBeNull();
+  });
+
+  it('escapes a malicious feature_image url', () => {
+    const el = mountWithConfig({ template: 'grid' });
+    const html = el.renderGridCard(
+      { document: { id: 'p1', feature_image: '"><script>alert(1)</script>', tags: [] } },
+      'T',
+      ''
+    );
+    expect(html).not.toContain('<script>');
+  });
+
+  it('adds feature_image to include_fields only in grid mode', () => {
+    expect(mountWithConfig({ template: 'grid' }).getSearchParameters().include_fields)
+      .toContain('feature_image');
+    expect(mountWithConfig().getSearchParameters().include_fields)
+      .not.toContain('feature_image');
+  });
+});

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -135,7 +135,11 @@ import Typesense from 'typesense';
                 ...defaultConfig,
                 commonSearches: defaultConfig.commonSearches || [],
                 pinnedSearches: defaultConfig.pinnedSearches || [],
-                facets: defaultConfig.facets || []
+                facets: defaultConfig.facets || [],
+                // Result layout: 'list' (default) or 'grid'. Normalise unknown
+                // values to 'list' so the default behaviour can't be changed by
+                // a typo.
+                template: defaultConfig.template === 'grid' ? 'grid' : 'list'
             };
 
             if (!this.config.typesenseNodes || !this.config.typesenseApiKey || !this.config.collectionName) {
@@ -782,21 +786,25 @@ import Typesense from 'typesense';
                         ? this.toRelativeUrl(hit.document.url)
                         : (hit.document.url || '#');
 
+                    // The link wrapper (class + data attributes + aria-label) is
+                    // shared by both templates, so keyboard navigation, click
+                    // handling, and analytics behave identically — only the
+                    // inner article markup differs.
                     return `
                         <a href="${resultUrl}"
                             class="${CSS_PREFIX}-result-link"
                             data-result-id="${this.escapeHtmlAttr(hit.document.id)}"
                             data-result-position="${index}"
                             aria-label="${title.replace(/<[^>]*>/g, '')}">
-                            <article class="${CSS_PREFIX}-result-item" role="article">
-                                <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}</h3>
-                                <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
-                            </article>
+                            ${this.config.template === 'grid'
+                                ? this.renderGridCard(hit, title, excerpt)
+                                : this.renderListItem(title, excerpt)}
                         </a>
                     `;
                 }).join('');
 
                 this.hitsList.innerHTML = resultsHtml;
+                this.hitsList.classList.toggle(`${CSS_PREFIX}-grid`, this.config.template === 'grid');
                 this.hitsList.classList.remove(`${CSS_PREFIX}-hidden`);
             } catch (error) {
                 if (this.loadingState) this.loadingState.classList.add(`${CSS_PREFIX}-hidden`);
@@ -875,6 +883,20 @@ import Typesense from 'typesense';
                     .filter(Boolean);
                 if (!fields.includes('id')) {
                     fields.unshift('id');
+                    mergedParams.include_fields = fields.join(',');
+                }
+            }
+
+            // The grid template shows the post's feature image, so make sure it
+            // is returned. Only added in grid mode, leaving the list/default
+            // query's returned fields unchanged.
+            if (this.config.template === 'grid') {
+                const fields = String(mergedParams.include_fields || '')
+                    .split(',')
+                    .map(f => f.trim())
+                    .filter(Boolean);
+                if (!fields.includes('feature_image')) {
+                    fields.push('feature_image');
                     mergedParams.include_fields = fields.join(',');
                 }
             }
@@ -1050,6 +1072,46 @@ import Typesense from 'typesense';
             if (query) {
                 this.handleSearch(query);
             }
+        }
+
+        // Default list layout: title + excerpt. `title` and `excerpt` already
+        // contain (Typesense-escaped) highlight markup.
+        renderListItem(title, excerpt) {
+            return `
+                <article class="${CSS_PREFIX}-result-item" role="article">
+                    <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}</h3>
+                    <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
+                </article>
+            `;
+        }
+
+        // Grid (card) layout: feature image, title, excerpt, and tags. The
+        // image is decorative (the link already carries the title via
+        // aria-label); when a post has no feature_image a styled placeholder is
+        // shown instead of a broken image.
+        renderGridCard(hit, title, excerpt) {
+            const featureImage = hit.document.feature_image;
+            const imageHtml = featureImage
+                ? `<img class="${CSS_PREFIX}-card-image" src="${this.escapeHtmlAttr(featureImage)}" alt="" loading="lazy" />`
+                : `<div class="${CSS_PREFIX}-card-image ${CSS_PREFIX}-card-image-empty" aria-hidden="true"></div>`;
+
+            const tags = Array.isArray(hit.document.tags) ? hit.document.tags.slice(0, 3) : [];
+            const tagsHtml = tags.length
+                ? `<div class="${CSS_PREFIX}-card-tags">${tags
+                    .map(tag => `<span class="${CSS_PREFIX}-card-tag">${this.escapeHtmlAttr(tag)}</span>`)
+                    .join('')}</div>`
+                : '';
+
+            return `
+                <article class="${CSS_PREFIX}-result-item ${CSS_PREFIX}-card" role="article">
+                    ${imageHtml}
+                    <div class="${CSS_PREFIX}-card-body">
+                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}</h3>
+                        <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
+                        ${tagsHtml}
+                    </div>
+                </article>
+            `;
         }
 
         handleKeydown(e) {

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -507,6 +507,68 @@
     word-break: break-word;
 }
 
+/* Grid (card) layout */
+.mp-search-hits-list.mp-search-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: calc(0.75 * var(--mp-rem));
+}
+
+.mp-search-grid .mp-search-result-item {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.mp-search-grid .mp-search-result-link:hover .mp-search-result-item,
+.mp-search-grid .mp-search-result-link.mp-search-selected .mp-search-result-item,
+.mp-search-grid .mp-search-result-link:focus .mp-search-result-item {
+    /* Cards lift instead of nudging sideways like list rows. */
+    transform: translateY(-2px);
+}
+
+.mp-search-card-image {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    display: block;
+}
+
+.mp-search-card-image-empty {
+    background: linear-gradient(135deg, var(--color-result-hover), var(--color-result-bg));
+}
+
+.mp-search-card-body {
+    padding: calc(1 * var(--mp-rem));
+    display: flex;
+    flex-direction: column;
+    gap: calc(0.375 * var(--mp-rem));
+}
+
+.mp-search-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(0.375 * var(--mp-rem));
+    margin-top: calc(0.25 * var(--mp-rem));
+}
+
+.mp-search-card-tag {
+    background: var(--color-result-hover);
+    border-radius: 999px;
+    color: var(--color-text-secondary);
+    font-size: calc(0.6875 * var(--mp-rem));
+    padding: calc(0.125 * var(--mp-rem)) calc(0.5 * var(--mp-rem));
+}
+
+@media (max-width: 640px) {
+    .mp-search-hits-list.mp-search-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* Keyboard hints */
 .mp-search-hints {
     display: flex;


### PR DESCRIPTION
## Summary

Adds an optional `template: 'list' | 'grid'` config (default `'list'`). The grid layout renders results as image-led cards — useful for photography, food, travel, and design publications where the list layout under-uses `feature_image`.

- **`'list'`** (default, unknown values normalised to it) — unchanged title-and-excerpt rows.
- **`'grid'`** — responsive cards (multi-column desktop, single column mobile) with `feature_image`, title, excerpt, and up to three tags. Posts without a feature image get a styled placeholder instead of a broken `<img>`.

Both templates share the same result data, highlighting, and — crucially — the same `<a class="mp-search-result-link" data-result-id data-result-position>` wrapper, so **keyboard navigation, click handling, and analytics behave identically**; only the inner `<article>` markup differs. `feature_image` is added to `include_fields` only in grid mode, so the list/default query's returned fields are unchanged. The image URL and tags are HTML-escaped (indexed content).

## Acceptance criteria

- [x] Default (`template` unset or `'list'`) is unchanged
- [x] `'grid'` renders responsive cards with `feature_image`, title, excerpt, tags
- [x] Cards without a feature image have a sensible fallback
- [x] Highlighting, keyboard navigation, and click handling work identically in both templates
- [x] README documents the `template` option

## Test plan

- [x] `npm test` — 33 tests (5 new: list/grid markup, missing-image fallback, image-URL escaping, grid-only `include_fields`)
- [x] `npm run lint` (5/5)
- [x] `npm test` at root → `turbo` 10/10
- [x] `npm run build` (5/5; grid markup + CSS confirmed in the bundle)

close #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `template` configuration option to switch search results between list and grid layouts.
  * Grid layout displays feature images alongside result titles, excerpts, and tags with responsive card styling.
  * Mobile-optimized view collapses grid to single column on smaller screens.

* **Documentation**
  * Updated configuration guide with new template setting and result layout options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->