### PR TITLE
feat: dev playground for the search UI (close #30)

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -1,0 +1,79 @@
+# Search UI playground
+
+A standalone dev harness for [`@magicpages/ghost-typesense-search-ui`](../../packages/search-ui). It loads the **built** widget the way Ghost does — a plain load of the shipped `search.min.js` — and drives it against a mocked Typesense backend, so you can iterate on the search UI and exercise every feature without a Ghost install or a running Typesense server.
+
+## Running it
+
+First build the widget the playground loads (re-run after any search-ui change):
+
+```bash
+npx turbo run build --filter=@magicpages/ghost-typesense-search-ui
+```
+
+Then start the playground. The default command brings up a real Typesense in Docker, seeds it, and starts the dev server — all in one step:
+
+```bash
+npm run dev --workspace @magicpages/ghost-typesense-playground
+```
+
+This requires Docker. It runs `docker compose up -d`, waits for Typesense to be healthy, seeds the sample posts (the first run downloads the embedding model, which can take a minute), then opens the playground. Choose options in the **Configuration** panel and press **Apply & open search**.
+
+No Docker? Use the zero-setup offline mock instead:
+
+```bash
+npm run dev:mock --workspace @magicpages/ghost-typesense-playground
+```
+
+Stop and reset the Typesense container with:
+
+```bash
+npm run typesense:down --workspace @magicpages/ghost-typesense-playground
+```
+
+## What you can toggle
+
+- **Template** — `list` (default) or `grid` (card layout with feature images).
+- **Theme** — `system` / `light` / `dark`.
+- **Facets** — reader-facing tag and author filters.
+- **Suggestions** — pinned + common search terms shown before typing.
+- **Semantic search** — appends the embedding field to the query (the mock returns the same results, but you can confirm the request shape).
+- **Analytics** — emitted `search` / `zero_result` / `click` events are captured and shown in the on-page **Events** log, along with the queries they carry.
+
+## Backends
+
+The playground picks a backend automatically, in this order:
+
+1. **An explicit endpoint** you type into the *Real Typesense endpoint* field.
+2. **The local Docker Typesense** at `localhost:8108`, if it's running — what `npm run dev` starts for you.
+3. **The built-in offline mock** otherwise — what `npm run dev:mock` uses.
+
+### Real Typesense via Docker (the default `npm run dev`)
+
+`npm run dev` orchestrates everything via [`scripts/dev.js`](./scripts/dev.js): `docker compose up -d` ([`docker-compose.yml`](./docker-compose.yml)) → wait for health → seed → Vite. The collection is created with an **embedding field**, so the semantic-search toggle runs a real hybrid query. The first run downloads the built-in model, which can take a minute.
+
+You can also run the pieces by hand: `docker compose up -d`, then `npm run seed`. Re-seeding is idempotent (it drops and recreates the collection).
+
+**Memory note.** Loading the embedding model needs a few hundred MB of free memory in the Typesense container. If it can't load, the seed prints a warning and **falls back to a lexical-only collection** — the playground stays fully usable, but the Semantic toggle is disabled and the Events log explains why. Give Docker more memory (Docker Desktop → Resources) and re-run `npm run seed` to enable it; set `SKIP_EMBEDDING=1` to skip the attempt deliberately.
+
+### Testing semantic search
+
+With embeddings enabled, semantic search matches on *meaning*, not shared words. Check **Semantic search**, Apply, and try a query whose words don't appear literally — e.g. `growing vegetables` or `cultivating plants` should still surface the gardening posts. Confirm the vector half ran via `vector_distance` on the hits:
+
+```bash
+curl -s 'http://localhost:8108/collections/ghost/documents/search?q=growing%20vegetables&query_by=title,plaintext,embedding' \
+  -H 'x-typesense-api-key: playground' | python3 -c "import sys,json; d=json.load(sys.stdin); print([(h['document']['title'], h.get('vector_distance')) for h in d['hits']])"
+```
+
+### Offline mock (`npm run dev:mock`)
+
+With no real instance reachable, the widget's Typesense node is pointed at the Vite dev server, and [`vite.config.js`](./vite.config.js) answers the `…/documents/search` endpoint from a small canned dataset ([`src/mock.js`](./src/mock.js)). Try `tomato`, `ghost`, or `garden`. Facet counts and highlighting are computed from that dataset. Note: with the mock, the *semantic search* toggle only changes the request shape — there is no real embedding model behind it.
+
+The seed data and the mock dataset are the same source ([`src/mock.js`](./src/mock.js)), so both backends search identical posts.
+
+### Another Typesense instance
+
+Paste a `https://host:port` URL into the *Real Typesense endpoint* field. It must have a `ghost` collection; the playground sends a placeholder API key, so set a real search-only key in [`src/main.js`](./src/main.js) if you point it at a production instance.
+
+## Notes
+
+This app is `private` and is not published. It has no unit tests of its own — it is a manual dev tool; the widget's behaviour is covered by the test suite in `packages/search-ui`.

--- a/apps/playground/docker-compose.yml
+++ b/apps/playground/docker-compose.yml
@@ -1,0 +1,30 @@
+# Local Typesense for the search UI playground.
+#
+#   docker compose up -d          # start Typesense on http://localhost:8108
+#   npm run seed                  # create the `ghost` collection + sample posts
+#
+# The data-dir is a named volume so the index survives restarts; remove it with
+# `docker compose down -v` for a clean slate. The api key matches what the seed
+# script and the playground use by default.
+services:
+  typesense:
+    # Pinned to a recent stable release that ships the built-in ML models, so
+    # the playground's semantic-search toggle works against real embeddings.
+    image: typesense/typesense:28.0
+    restart: unless-stopped
+    ports:
+      - '8108:8108'
+    volumes:
+      - typesense-data:/data
+    command: >
+      --data-dir /data
+      --api-key=playground
+      --enable-cors
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8108/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  typesense-data:

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ghost + Typesense search UI — playground</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #fbfbfc;
+        --fg: #15171a;
+        --muted: #6b7280;
+        --border: #e4e6eb;
+        --accent: #6d28d9;
+        --card: #ffffff;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #15171a;
+          --fg: #f4f5f6;
+          --muted: #9aa1ac;
+          --border: #2a2d33;
+          --card: #1c1f24;
+        }
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--bg); color: var(--fg); line-height: 1.5; padding: 32px 20px 64px; }
+      main { max-width: 880px; margin: 0 auto; }
+      header h1 { margin: 0 0 4px; font-size: 22px; }
+      header p { margin: 0 0 24px; color: var(--muted); font-size: 14px; }
+      code { font-size: 12px; }
+      .card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 20px; margin-bottom: 20px; }
+      .card h2 { margin: 0 0 14px; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+      .row { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+      .row + .row { margin-top: 12px; }
+      label { font-size: 13px; color: var(--fg); display: inline-flex; gap: 6px; align-items: center; }
+      select, input[type='url'] {
+        font: inherit; font-size: 13px; padding: 7px 8px; border: 1px solid var(--border);
+        border-radius: 8px; background: var(--bg); color: var(--fg);
+      }
+      input[type='url'] { flex: 1 1 320px; min-width: 0; }
+      button {
+        font: inherit; font-size: 13px; padding: 8px 14px; border: 1px solid var(--border);
+        border-radius: 8px; background: var(--card); color: var(--fg); cursor: pointer;
+        transition: border-color 0.15s;
+      }
+      button:hover { border-color: var(--accent); }
+      button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+      pre.log {
+        margin: 0; max-height: 260px; overflow: auto; padding: 12px 14px; background: var(--bg);
+        border: 1px solid var(--border); border-radius: 8px; font-size: 12px; line-height: 1.6;
+        white-space: pre-wrap; word-break: break-word;
+      }
+      .log .ev-query { color: #2563eb; }
+      .log .ev-analytics { color: #16a34a; }
+      .log .ev-info { color: var(--muted); }
+      .log .ev-error { color: #dc2626; }
+      .hint { font-size: 12px; color: var(--muted); margin-top: 8px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Search UI playground</h1>
+        <p>
+          Loads the built <code>/search.min.js</code> the way Ghost does, against a mocked
+          Typesense backend — so you can drive the widget and every feature without a Ghost
+          install or a real Typesense server. Press <code>/</code> or <kbd>Cmd/Ctrl&nbsp;+&nbsp;K</kbd>,
+          or click <em>Open search</em>.
+        </p>
+      </header>
+
+      <div class="card">
+        <h2>Configuration</h2>
+        <div class="row">
+          <label>Template
+            <select id="opt-template">
+              <option value="list">list</option>
+              <option value="grid">grid</option>
+            </select>
+          </label>
+          <label>Theme
+            <select id="opt-theme">
+              <option value="system">system</option>
+              <option value="light">light</option>
+              <option value="dark">dark</option>
+            </select>
+          </label>
+          <label><input type="checkbox" id="opt-facets" /> Facets (tags + authors)</label>
+          <label><input type="checkbox" id="opt-suggestions" /> Pinned + common suggestions</label>
+          <label><input type="checkbox" id="opt-semantic" /> Semantic search</label>
+          <label><input type="checkbox" id="opt-analytics" checked /> Analytics (logged below)</label>
+        </div>
+        <div class="row">
+          <label>Real Typesense endpoint (optional)
+            <input type="url" id="opt-endpoint" placeholder="https://host:443  — leave blank to use the mock" />
+          </label>
+        </div>
+        <div class="row">
+          <button class="primary" id="apply" type="button">Apply &amp; open search</button>
+          <button id="open" type="button">Open search</button>
+          <button id="clear-log" type="button">Clear log</button>
+        </div>
+        <p class="hint">
+          Applying re-creates the widget with the chosen config. Leave the endpoint blank to search
+          the built-in mock dataset (try “tomato”, “ghost”, “garden”).
+        </p>
+      </div>
+
+      <div class="card">
+        <h2>Events</h2>
+        <pre class="log" id="log"></pre>
+      </div>
+    </main>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@magicpages/ghost-typesense-playground",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Standalone dev harness for the search UI — no Ghost required.",
+  "type": "module",
+  "scripts": {
+    "dev": "node scripts/dev.js",
+    "dev:mock": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "seed": "node scripts/seed.js",
+    "typesense:down": "docker compose down -v"
+  },
+  "dependencies": {
+    "@magicpages/ghost-typesense-search-ui": "*",
+    "typesense": "^1.7.2"
+  },
+  "devDependencies": {
+    "vite": "^5.1.0"
+  }
+}

--- a/apps/playground/scripts/dev.js
+++ b/apps/playground/scripts/dev.js
@@ -1,0 +1,70 @@
+// One-command playground: bring up the Docker Typesense, wait for it, seed it
+// with the sample posts, then start Vite. Run with `npm run dev`.
+//
+// Requires Docker. If you don't have Docker (or want the zero-setup offline
+// mock), use `npm run dev:mock` instead — that skips Typesense entirely and the
+// playground falls back to the in-process mock backend.
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const playgroundDir = resolve(here, '..');
+const HEALTH_URL = 'http://localhost:8108/health';
+
+function fail(message) {
+  console.error(`\n✖ ${message}\n`);
+  process.exit(1);
+}
+
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { cwd: playgroundDir, stdio: 'inherit', ...opts });
+  if (res.error) throw res.error;
+  return res.status ?? 1;
+}
+
+// 1. Docker must be installed and the daemon reachable.
+const dockerOk = spawnSync('docker', ['info'], { stdio: 'ignore' });
+if (dockerOk.error || dockerOk.status !== 0) {
+  fail(
+    'Docker is required for `npm run dev` (it runs a real Typesense).\n' +
+      '  • Start Docker and try again, or\n' +
+      '  • run `npm run dev:mock` to use the zero-setup offline mock instead.'
+  );
+}
+
+// 2. Start Typesense.
+console.log('▸ Starting Typesense (docker compose up -d) …');
+if (run('docker', ['compose', 'up', '-d']) !== 0) {
+  fail('`docker compose up -d` failed. Check the Docker logs and try again.');
+}
+
+// 3. Wait for health.
+console.log('▸ Waiting for Typesense to be healthy …');
+const deadline = Date.now() + 60_000;
+let healthy = false;
+while (Date.now() < deadline) {
+  try {
+    const res = await fetch(HEALTH_URL, { signal: AbortSignal.timeout(1000) });
+    if (res.ok) { healthy = true; break; }
+  } catch {
+    /* not up yet */
+  }
+  await new Promise((r) => setTimeout(r, 1000));
+}
+if (!healthy) fail('Typesense did not become healthy within 60s. Try `docker compose logs`.');
+
+// 4. Seed (idempotent: drops + recreates). The first run downloads the
+//    embedding model, which can take a while.
+console.log('▸ Seeding sample posts (first run downloads the embedding model — may take a minute) …');
+if (run('node', ['scripts/seed.js']) !== 0) {
+  fail('Seeding failed. See the output above.');
+}
+
+// 5. Start Vite in the foreground; hand over signal handling to it.
+console.log('▸ Starting the playground …\n');
+const vite = spawn('npx', ['vite'], { cwd: playgroundDir, stdio: 'inherit' });
+vite.on('exit', (code) => process.exit(code ?? 0));
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => vite.kill(sig));
+}

--- a/apps/playground/scripts/seed.js
+++ b/apps/playground/scripts/seed.js
@@ -1,0 +1,144 @@
+// Seed the local Docker Typesense (see docker-compose.yml) with the sample
+// posts so the playground can search a real Typesense instance — including
+// real semantic search, since the collection is created with an auto-embedding
+// field.
+//
+//   docker compose up -d
+//   npm run seed
+//
+// Re-running is safe: the collection is dropped and recreated.
+import Typesense from 'typesense';
+import { POSTS } from '../src/mock.js';
+
+const HOST = process.env.TYPESENSE_HOST || 'localhost';
+const PORT = Number(process.env.TYPESENSE_PORT || 8108);
+const PROTOCOL = process.env.TYPESENSE_PROTOCOL || 'http';
+const API_KEY = process.env.TYPESENSE_API_KEY || 'playground';
+const COLLECTION = process.env.TYPESENSE_COLLECTION || 'ghost';
+
+const client = new Typesense.Client({
+  nodes: [{ host: HOST, port: PORT, protocol: PROTOCOL }],
+  apiKey: API_KEY,
+  // Creating the collection downloads the embedding model on first run, which
+  // can take a while — give it a generous timeout with a few retries.
+  connectionTimeoutSeconds: 120,
+  numRetries: 3,
+  retryIntervalSeconds: 3
+});
+
+const schema = {
+  name: COLLECTION,
+  enable_nested_fields: true,
+  fields: [
+    { name: 'id', type: 'string' },
+    { name: 'title', type: 'string' },
+    { name: 'slug', type: 'string' },
+    { name: 'url', type: 'string' },
+    { name: 'excerpt', type: 'string' },
+    { name: 'plaintext', type: 'string' },
+    { name: 'feature_image', type: 'string', optional: true },
+    { name: 'published_at', type: 'int64' },
+    // Mirror the fields the real indexer (packages/core) produces and the
+    // widget queries: a flat `tags` array plus the nested `tags.name` /
+    // `tags.slug`. Omitting the nested fields makes Typesense reject the
+    // widget's default query_by with "Could not find a field named tags.name".
+    { name: 'tags', type: 'string[]', facet: true, optional: true },
+    { name: 'tags.name', type: 'string[]', facet: true, optional: true },
+    { name: 'tags.slug', type: 'string[]', facet: true, optional: true },
+    { name: 'authors', type: 'string[]', facet: true, optional: true }
+  ]
+};
+
+// Auto-embedding field — appended only when embeddings are enabled. On first
+// use Typesense downloads the built-in model (~120MB) and caches it under
+// /data/models; that download takes a moment and needs network + some free
+// memory. If it can't initialize, the seed falls back to a collection without
+// embeddings.
+const embeddingField = {
+  name: 'embedding',
+  type: 'float[]',
+  optional: true,
+  embed: {
+    from: ['title', 'excerpt', 'plaintext'],
+    // Typesense's officially bundled built-in model (downloaded on first use).
+    // Must be a model from Typesense's repo — a made-up name yields
+    // "Model not found".
+    model_config: { model_name: 'ts/all-MiniLM-L12-v2' }
+  }
+};
+
+const WANT_EMBEDDING = process.env.SKIP_EMBEDDING !== '1';
+
+// The embedding model can fail to initialize for a few reasons: the model
+// couldn't be downloaded (no network in the container), it isn't a real model
+// in Typesense's repo ("Model not found"), or there wasn't enough memory to
+// load it. Any of these should degrade gracefully rather than abort the seed.
+function isModelInitError(err) {
+  const msg = String(err?.message || err).toLowerCase();
+  return msg.includes('model') || msg.includes('memory') || msg.includes('embed');
+}
+
+async function createCollection() {
+  if (WANT_EMBEDDING) {
+    try {
+      // The first run downloads the model (~120MB), which can take a minute.
+      await client.collections().create({ ...schema, fields: [...schema.fields, embeddingField] });
+      console.log(`Created "${COLLECTION}" collection (with embedding field — semantic search enabled).`);
+      return true;
+    } catch (err) {
+      if (!isModelInitError(err)) throw err;
+      console.warn(
+        `⚠ Could not initialize the embedding model (${err?.message || err}).\n` +
+          '  Falling back to a collection WITHOUT embeddings — semantic search will be\n' +
+          '  unavailable, but everything else works. Common causes: the model download\n' +
+          '  needs network access from the container and a minute to complete, or the\n' +
+          '  container is low on memory. Fix the cause and re-run `npm run seed`, or set\n' +
+          '  SKIP_EMBEDDING=1 to skip the attempt deliberately.'
+      );
+      // The failed attempt may have left a partial collection behind.
+      await client.collections(COLLECTION).delete().catch(() => {});
+    }
+  }
+  await client.collections().create(schema);
+  console.log(`Created "${COLLECTION}" collection (no embedding field — lexical search only).`);
+  return false;
+}
+
+async function main() {
+  try {
+    await client.collections(COLLECTION).delete();
+    console.log(`Dropped existing "${COLLECTION}" collection.`);
+  } catch {
+    // Collection didn't exist yet — fine.
+  }
+
+  await createCollection();
+
+  const slugify = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const documents = POSTS.map(({ feature_image, tags = [], ...rest }) => ({
+    ...rest,
+    tags,
+    // The widget's default query_by/facets use the nested fields, so provide
+    // them the way packages/core does.
+    'tags.name': tags,
+    'tags.slug': tags.map(slugify),
+    // Typesense rejects null for an optional string; omit instead.
+    ...(feature_image ? { feature_image } : {})
+  }));
+
+  const results = await client.collections(COLLECTION).documents().import(documents, { action: 'upsert' });
+  const failed = results.filter((r) => !r.success);
+  console.log(`Imported ${documents.length - failed.length}/${documents.length} posts.`);
+  if (failed.length) {
+    console.error('Some documents failed:', failed);
+    process.exitCode = 1;
+  } else {
+    console.log('Done. Point the playground at http://localhost:8108 (or just reload — it auto-detects).');
+  }
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err?.message || err);
+  console.error('Is Typesense running? Try `docker compose up -d` first.');
+  process.exit(1);
+});

--- a/apps/playground/src/main.js
+++ b/apps/playground/src/main.js
@@ -1,0 +1,298 @@
+// Playground wiring: read the controls, assemble window.__MP_SEARCH_CONFIG__,
+// (re)load the built widget the way Ghost does, and surface analytics events in
+// an on-page log.
+
+const SEARCH_BUNDLE_URL = '/search.min.js';
+
+const els = {
+  template: document.getElementById('opt-template'),
+  theme: document.getElementById('opt-theme'),
+  facets: document.getElementById('opt-facets'),
+  suggestions: document.getElementById('opt-suggestions'),
+  semantic: document.getElementById('opt-semantic'),
+  analytics: document.getElementById('opt-analytics'),
+  endpoint: document.getElementById('opt-endpoint'),
+  apply: document.getElementById('apply'),
+  open: document.getElementById('open'),
+  clearLog: document.getElementById('clear-log'),
+  log: document.getElementById('log')
+};
+
+function stamp() {
+  return new Date().toISOString().slice(11, 19);
+}
+
+function write(line, kind = 'info') {
+  const span = document.createElement('span');
+  span.className = `ev-${kind}`;
+  span.textContent = `[${stamp()}] ${line}\n`;
+  els.log.appendChild(span);
+  els.log.scrollTop = els.log.scrollHeight;
+}
+
+// The widget reports analytics via navigator.sendBeacon. Intercept it so the
+// playground can show search/click/zero_result events (and the queries they
+// carry) without a backend.
+const ANALYTICS_ENDPOINT = '/__playground_analytics';
+const realSendBeacon = navigator.sendBeacon ? navigator.sendBeacon.bind(navigator) : null;
+navigator.sendBeacon = (url, data) => {
+  if (typeof url === 'string' && url.includes('__playground_analytics')) {
+    readBeacon(data).then((payload) => {
+      if (!payload) return;
+      const detail =
+        payload.type === 'click'
+          ? `click → "${payload.q}" → ${payload.resultId} (pos ${payload.position})`
+          : `${payload.type} → "${payload.q}" (${payload.resultCount} results)`;
+      write(detail, 'analytics');
+    });
+    return true;
+  }
+  return realSendBeacon ? realSendBeacon(url, data) : true;
+};
+
+async function readBeacon(data) {
+  try {
+    if (data instanceof Blob) return JSON.parse(await data.text());
+    if (typeof data === 'string') return JSON.parse(data);
+  } catch {
+    /* ignore malformed beacon payloads */
+  }
+  return null;
+}
+
+const LOCAL_TYPESENSE = { host: 'localhost', port: 8108, protocol: 'http', apiKey: 'playground' };
+
+// Has the Docker Typesense from docker-compose.yml been started and seeded?
+// Probed once so the playground can prefer a real instance when it's available.
+let localTypesense = null;
+async function detectLocalTypesense() {
+  if (localTypesense !== null) return localTypesense;
+  try {
+    const res = await fetch(`${LOCAL_TYPESENSE.protocol}://${LOCAL_TYPESENSE.host}:${LOCAL_TYPESENSE.port}/health`, {
+      signal: AbortSignal.timeout(800)
+    });
+    localTypesense = res.ok;
+  } catch {
+    localTypesense = false;
+  }
+  return localTypesense;
+}
+
+// Does the active backend's `ghost` collection actually have an embedding
+// field? The seed falls back to a lexical-only collection when the embedding
+// model can't load (e.g. not enough memory in the Docker container), and the
+// offline mock has no real embeddings at all — in both cases semantic search
+// is a no-op, so the playground needs to know and say so.
+let embeddingSupport = null;
+async function detectEmbeddingSupport(node, apiKey) {
+  try {
+    const res = await fetch(`${node.protocol}://${node.host}:${node.port}/collections/ghost`, {
+      headers: { 'x-typesense-api-key': apiKey },
+      signal: AbortSignal.timeout(1500)
+    });
+    if (!res.ok) return false;
+    const schema = await res.json();
+    return Array.isArray(schema.fields) && schema.fields.some((f) => f.embed || f.name === 'embedding');
+  } catch {
+    // The mock backend doesn't answer /collections/ghost — treat as no support.
+    return false;
+  }
+}
+
+// Reflect embedding availability in the Semantic toggle so it can't silently be
+// a no-op.
+function applyEmbeddingState(supported, usingMock) {
+  embeddingSupport = supported;
+  const label = els.semantic.closest('label');
+  if (supported) {
+    els.semantic.disabled = false;
+    if (label) label.title = 'Hybrid keyword + vector search';
+    return;
+  }
+  els.semantic.disabled = true;
+  els.semantic.checked = false;
+  if (label) {
+    label.style.opacity = '0.55';
+    label.title = usingMock
+      ? 'Semantic search needs a real Typesense — run `npm run dev` with Docker.'
+      : 'This collection was seeded without embeddings (model could not load). Give Docker more memory and re-run `npm run seed`.';
+  }
+}
+
+// Decide which backend to use, in priority order:
+//   1. an explicit endpoint typed into the field
+//   2. the local Docker Typesense, if it's up (real engine + real semantic search)
+//   3. the built-in offline mock served by this dev server
+function resolveBackend() {
+  const raw = els.endpoint.value.trim();
+  if (raw) {
+    try {
+      const u = new URL(raw);
+      write(`using real Typesense at ${u.host}`);
+      return {
+        node: { host: u.hostname, port: Number(u.port) || (u.protocol === 'https:' ? 443 : 80), protocol: u.protocol.replace(':', '') },
+        apiKey: 'playground-search-only-key'
+      };
+    } catch {
+      write(`could not parse endpoint "${raw}", falling back`, 'error');
+    }
+  }
+
+  if (localTypesense) {
+    write('using local Docker Typesense at localhost:8108');
+    return { node: { host: LOCAL_TYPESENSE.host, port: LOCAL_TYPESENSE.port, protocol: LOCAL_TYPESENSE.protocol }, apiKey: LOCAL_TYPESENSE.apiKey };
+  }
+
+  write('using built-in mock backend on this dev server');
+  return {
+    node: { host: location.hostname, port: Number(location.port) || 80, protocol: location.protocol.replace(':', '') },
+    apiKey: 'playground-search-only-key'
+  };
+}
+
+function buildConfig(backend) {
+  const config = {
+    typesenseNodes: [backend.node],
+    typesenseApiKey: backend.apiKey,
+    collectionName: 'ghost',
+    theme: els.theme.value,
+    template: els.template.value,
+    enableHighlighting: true
+  };
+
+  if (els.facets.checked) {
+    config.facets = [
+      { field: 'tags.name', label: 'Topics', limit: 10 },
+      { field: 'authors', label: 'Authors', limit: 10 }
+    ];
+  }
+  if (els.suggestions.checked) {
+    config.pinnedSearches = ['Ghost'];
+    config.commonSearches = ['tomatoes', 'garden', 'theme'];
+  }
+  if (els.semantic.checked && embeddingSupport) {
+    config.semanticSearch = true;
+  }
+  if (els.analytics.checked) {
+    config.analytics = { endpoint: ANALYTICS_ENDPOINT, siteId: 'playground' };
+  }
+  return config;
+}
+
+// The widget is a single-instance Web Component: it reads its config once, when
+// it first initializes, and guards against re-initialization. So rather than
+// swap the element in place, applying new options persists them and reloads —
+// the same way a real site loads the widget fresh with a given config. This
+// also sidesteps the component's one-time init guard entirely.
+const STORAGE_KEY = 'mp-playground-state';
+
+function readControls() {
+  return {
+    template: els.template.value,
+    theme: els.theme.value,
+    facets: els.facets.checked,
+    suggestions: els.suggestions.checked,
+    semantic: els.semantic.checked,
+    analytics: els.analytics.checked,
+    endpoint: els.endpoint.value.trim()
+  };
+}
+
+function restoreControls(state) {
+  if (!state) return;
+  els.template.value = state.template ?? 'list';
+  els.theme.value = state.theme ?? 'system';
+  els.facets.checked = !!state.facets;
+  els.suggestions.checked = !!state.suggestions;
+  els.semantic.checked = !!state.semantic;
+  els.analytics.checked = state.analytics !== false;
+  els.endpoint.value = state.endpoint ?? '';
+}
+
+function apply() {
+  // Persist the chosen options and reload; loadWidget() picks them up.
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ ...readControls(), open: true }));
+  location.reload();
+}
+
+// On load: if options were applied, build the config, load the built bundle the
+// way Ghost does, and open the modal once the widget has initialized.
+async function loadWidget() {
+  let state = null;
+  try {
+    state = JSON.parse(sessionStorage.getItem(STORAGE_KEY) || 'null');
+  } catch {
+    /* ignore */
+  }
+  restoreControls(state);
+
+  if (!state) {
+    // Annotate the Semantic toggle on first load too, so its availability is
+    // clear before the first Apply.
+    await detectLocalTypesense();
+    const backend = resolveBackend();
+    const usingMock = !els.endpoint.value.trim() && !localTypesense;
+    applyEmbeddingState(usingMock ? false : await detectEmbeddingSupport(backend.node, backend.apiKey), usingMock);
+    write('ready — choose options and press “Apply & open search”.');
+    return;
+  }
+
+  await detectLocalTypesense();
+  const backend = resolveBackend();
+
+  // Check whether semantic search is actually available on this backend and
+  // reflect it in the UI before building the config.
+  const usingMock = !els.endpoint.value.trim() && !localTypesense;
+  const supported = usingMock ? false : await detectEmbeddingSupport(backend.node, backend.apiKey);
+  applyEmbeddingState(supported, usingMock);
+  if (els.semantic.checked && !supported) {
+    write(
+      usingMock
+        ? 'semantic search unavailable on the mock backend — start the Docker Typesense with `npm run dev`'
+        : 'semantic search unavailable — the collection was seeded without embeddings (model could not load); give Docker more memory and re-run `npm run seed`',
+      'error'
+    );
+  } else if (supported) {
+    write('semantic search available (collection has an embedding field)');
+  }
+
+  const config = buildConfig(backend);
+  window.__MP_SEARCH_CONFIG__ = config;
+  write(`config applied: template=${config.template}, facets=${!!config.facets}, semantic=${!!config.semanticSearch}, analytics=${!!config.analytics}`);
+
+  try {
+    // Dynamic import of the shipped artifact — the widget auto-creates its own
+    // instance and sets window.magicPagesSearch because the config is present.
+    await import(/* @vite-ignore */ SEARCH_BUNDLE_URL);
+    write(`loaded ${SEARCH_BUNDLE_URL}`);
+  } catch (err) {
+    write(`failed to load ${SEARCH_BUNDLE_URL}: ${err?.message || err}`, 'error');
+    return;
+  }
+
+  if (state.open) {
+    // Wait for the widget's async init to finish wiring up the modal, then open.
+    await waitFor(() => window.magicPagesSearch && typeof window.magicPagesSearch.openModal === 'function');
+    window.magicPagesSearch.openModal();
+    write('search opened — type to query (try “tomato”, “ghost”, “garden”)');
+  }
+}
+
+function waitFor(predicate, timeoutMs = 3000) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    (function check() {
+      if (predicate() || Date.now() - start > timeoutMs) return resolve();
+      setTimeout(check, 30);
+    })();
+  });
+}
+
+els.apply.addEventListener('click', apply);
+els.open.addEventListener('click', () => {
+  if (window.magicPagesSearch) window.magicPagesSearch.openModal();
+  else apply();
+});
+els.clearLog.addEventListener('click', () => els.log.replaceChildren());
+
+void loadWidget();

--- a/apps/playground/src/mock.js
+++ b/apps/playground/src/mock.js
@@ -1,0 +1,137 @@
+// A small fake Ghost dataset and a minimal Typesense-shaped search responder,
+// so the playground demonstrates the widget offline. This is intentionally not
+// a Typesense reimplementation — it honours just enough (`q` substring match,
+// `filter_by` facet equality, `facet_by` counts, basic highlighting) to make
+// the search, suggestions, facet, and grid features visible.
+
+export const POSTS = [
+  {
+    id: 'post-1',
+    title: 'Growing tomatoes on a balcony',
+    slug: 'growing-tomatoes',
+    url: 'https://demo.example.com/growing-tomatoes/',
+    excerpt: 'Everything you need to turn a sunny balcony into a small tomato garden.',
+    plaintext: 'Tomatoes love sun and water. Start with seedlings, use deep pots, and feed weekly.',
+    feature_image: 'https://images.unsplash.com/photo-1592841200221-a6898f307baa?w=1200&q=80',
+    published_at: 1700000000000,
+    tags: ['Gardening', 'How To'],
+    authors: ['Jannis']
+  },
+  {
+    id: 'post-2',
+    title: 'A vegetable garden plan for beginners',
+    slug: 'vegetable-garden-plan',
+    url: 'https://demo.example.com/vegetable-garden-plan/',
+    excerpt: 'Lay out your first vegetable garden with this simple seasonal plan.',
+    plaintext: 'Plan beds by sunlight, rotate crops, and start with easy vegetables like lettuce and beans.',
+    feature_image: 'https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=1200&q=80',
+    published_at: 1699000000000,
+    tags: ['Gardening'],
+    authors: ['Sam']
+  },
+  {
+    id: 'post-3',
+    title: 'Migrating your blog to Ghost',
+    slug: 'migrating-to-ghost',
+    url: 'https://demo.example.com/migrating-to-ghost/',
+    excerpt: 'A step-by-step guide to moving an existing site onto Ghost.',
+    plaintext: 'Export your content, map authors and tags, import into Ghost, then verify redirects.',
+    feature_image: null,
+    published_at: 1698000000000,
+    tags: ['Ghost', 'How To'],
+    authors: ['Jannis']
+  },
+  {
+    id: 'post-4',
+    title: 'Designing a fast Ghost theme',
+    slug: 'fast-ghost-theme',
+    url: 'https://demo.example.com/fast-ghost-theme/',
+    excerpt: 'Performance tips for building a Ghost theme that loads instantly.',
+    plaintext: 'Inline critical CSS, lazy-load images, and keep JavaScript minimal for a fast theme.',
+    feature_image: 'https://images.unsplash.com/photo-1507238691740-187a5b1d37b8?w=1200&q=80',
+    published_at: 1697000000000,
+    tags: ['Ghost', 'Design'],
+    authors: ['Sam']
+  }
+];
+
+// Parse a Typesense filter_by clause like `tags:=[`Ghost`,`Design`] && authors:=[`Sam`]`
+// into { field: [values] }. Only the subset the widget emits is handled.
+function parseFilterBy(filterBy) {
+  const filters = {};
+  if (!filterBy) return filters;
+  // Split on top-level && (the widget never nests beyond one level of parens).
+  for (const clause of filterBy.replace(/[()]/g, '').split('&&')) {
+    const match = clause.trim().match(/^([\w.]+):=\[(.*)\]$/);
+    if (!match) continue;
+    const [, field, rawValues] = match;
+    filters[field] = rawValues
+      .split(',')
+      .map((v) => v.trim().replace(/^`|`$/g, ''))
+      .filter(Boolean);
+  }
+  return filters;
+}
+
+function matchesFilters(post, filters) {
+  return Object.entries(filters).every(([field, values]) => {
+    const docValue = field === 'tags.name' ? post.tags : post[field];
+    const have = Array.isArray(docValue) ? docValue : [docValue];
+    return values.some((v) => have.includes(v));
+  });
+}
+
+function highlight(text, q) {
+  if (!q) return { snippet: text };
+  const idx = text.toLowerCase().indexOf(q.toLowerCase());
+  if (idx === -1) return { snippet: text };
+  const snippet = `${text.slice(0, idx)}<mark>${text.slice(idx, idx + q.length)}</mark>${text.slice(idx + q.length)}`;
+  return { snippet };
+}
+
+export function mockSearchResponse(params = {}) {
+  const q = (params.q || '').trim();
+  const filters = parseFilterBy(params.filter_by);
+  const facetBy = (params.facet_by || '').split(',').map((f) => f.trim()).filter(Boolean);
+
+  const filtered = POSTS.filter((p) => {
+    if (!matchesFilters(p, filters)) return false;
+    if (!q || q === '*') return true;
+    const haystack = `${p.title} ${p.excerpt} ${p.plaintext} ${p.tags.join(' ')}`.toLowerCase();
+    return haystack.includes(q.toLowerCase());
+  });
+
+  const hits = filtered.map((document) => ({
+    document,
+    highlight: {
+      title: highlight(document.title, q),
+      excerpt: highlight(document.excerpt, q)
+    }
+  }));
+
+  // Facet counts are computed over the filtered set, mirroring how Typesense
+  // narrows counts as filters are applied.
+  const facet_counts = facetBy.map((field) => {
+    const counts = {};
+    for (const post of filtered) {
+      const values = field === 'tags.name' ? post.tags : [].concat(post[field] || []);
+      for (const value of values) counts[value] = (counts[value] || 0) + 1;
+    }
+    return {
+      field_name: field,
+      counts: Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count, highlighted: value }))
+    };
+  });
+
+  return {
+    facet_counts,
+    found: hits.length,
+    hits,
+    out_of: POSTS.length,
+    page: 1,
+    request_params: { collection_name: 'ghost', q, per_page: 20 },
+    search_time_ms: 1
+  };
+}

--- a/apps/playground/vite.config.js
+++ b/apps/playground/vite.config.js
@@ -1,0 +1,85 @@
+import { readFile, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import { mockSearchResponse } from './src/mock.js';
+
+const searchUiDist = resolve(__dirname, '../../packages/search-ui/dist');
+
+/**
+ * Serve the built search widget at `/search.min.js`, straight from
+ * `packages/search-ui/dist` with no Vite module transform — the same shape
+ * Ghost loads in production (a plain `<script>` of the shipped bundle). If the
+ * bundle hasn't been built yet, return a clear error rather than a 404 that
+ * looks like a routing bug.
+ */
+function serveSearchBundle() {
+  return {
+    name: 'serve-search-bundle',
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        if (!/^\/search\.min\.js(?:\?.*)?$/.test(req.url ?? '')) return next();
+        const filePath = resolve(searchUiDist, 'search.min.js');
+        try {
+          await stat(filePath);
+        } catch {
+          res.statusCode = 503;
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+          res.end(
+            'search.min.js not built yet — run `npm run build` in packages/search-ui ' +
+              '(or `npx turbo run build --filter=@magicpages/ghost-typesense-search-ui`).'
+          );
+          return;
+        }
+        res.setHeader('Content-Type', 'text/javascript; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-store');
+        res.end(await readFile(filePath));
+      });
+    }
+  };
+}
+
+/**
+ * Answer the Typesense documents-search endpoint with a canned response so the
+ * playground works fully offline. The real widget builds and sends the request
+ * via its Typesense client; only the network reply is faked, so search,
+ * facets, and highlighting all run through the actual widget code.
+ *
+ * Pointing the widget's node at this dev server (see index.html) routes its
+ * search requests here.
+ */
+function mockTypesense() {
+  return {
+    name: 'mock-typesense',
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const url = req.url ?? '';
+        if (!/\/collections\/[^/]+\/documents\/search/.test(url)) return next();
+
+        // Search params arrive in the query string (GET) for this client.
+        const params = Object.fromEntries(new URL(url, 'http://localhost').searchParams);
+        const body = mockSearchResponse(params);
+
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.end(JSON.stringify(body));
+      });
+    }
+  };
+}
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [serveSearchBundle(), mockTypesense()],
+  server: {
+    port: 5174,
+    open: true,
+    fs: {
+      // Allow reading the built bundle from the sibling package.
+      allow: [resolve(__dirname, '../../')]
+    }
+  },
+  build: {
+    target: 'es2020'
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "apps/playground": {
+      "name": "@magicpages/ghost-typesense-playground",
+      "version": "0.0.0",
+      "dependencies": {
+        "@magicpages/ghost-typesense-search-ui": "*",
+        "typesense": "^1.7.2"
+      },
+      "devDependencies": {
+        "vite": "^5.1.0"
+      }
+    },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
       "version": "1.12.0",
@@ -1421,6 +1432,10 @@
     },
     "node_modules/@magicpages/ghost-typesense-core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@magicpages/ghost-typesense-playground": {
+      "resolved": "apps/playground",
       "link": true
     },
     "node_modules/@magicpages/ghost-typesense-search-ui": {
@@ -10199,6 +10214,14 @@
             "glob": "^10.3.7"
           }
         }
+      }
+    },
+    "@magicpages/ghost-typesense-playground": {
+      "version": "file:apps/playground",
+      "requires": {
+        "@magicpages/ghost-typesense-search-ui": "*",
+        "typesense": "^1.7.2",
+        "vite": "^5.1.0"
       }
     },
     "@magicpages/ghost-typesense-search-ui": {

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -42,6 +42,28 @@ describe('getSearchParameters — lexical baseline', () => {
   });
 });
 
+describe('getSearchParameters — semantic search', () => {
+  it('appends the embedding field to query_by when enabled', () => {
+    const params = mountWithConfig({ semanticSearch: true }).getSearchParameters();
+    expect(params.query_by.split(',')).toContain('embedding');
+  });
+
+  it('keeps query_by_weights the same length as query_by (Typesense requires it)', () => {
+    const params = mountWithConfig({ semanticSearch: true }).getSearchParameters();
+    expect(params.query_by_weights.split(',').length).toBe(params.query_by.split(',').length);
+  });
+
+  it('respects a custom embeddingFieldName', () => {
+    const params = mountWithConfig({ semanticSearch: true, embeddingFieldName: 'vec' }).getSearchParameters();
+    expect(params.query_by.split(',')).toContain('vec');
+  });
+
+  it('does not touch query_by when disabled', () => {
+    const params = mountWithConfig().getSearchParameters();
+    expect(params.query_by.split(',')).not.toContain('embedding');
+  });
+});
+
 describe('getSearchParameters — facets', () => {
   const facetConfig = {
     facets: [

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -904,8 +904,7 @@ import Typesense from 'typesense';
             // Semantic (hybrid) search: when enabled, append the embedding
             // field to `query_by`. Typesense then fuses keyword and vector
             // relevance, auto-embedding the query against the field's model.
-            // The vector field carries no keyword weight, so query_by_weights
-            // is left untouched. When disabled, queries stay purely lexical.
+            // When disabled, queries stay purely lexical.
             if (this.config.semanticSearch) {
                 const embeddingField = this.config.embeddingFieldName || 'embedding';
                 const queryFields = String(mergedParams.query_by || '')
@@ -915,6 +914,19 @@ import Typesense from 'typesense';
                 if (!queryFields.includes(embeddingField)) {
                     queryFields.push(embeddingField);
                     mergedParams.query_by = queryFields.join(',');
+
+                    // Typesense requires query_by_weights to have the same number
+                    // of entries as query_by when it is set, so add a weight for
+                    // the embedding field too. (When no weights are set, leaving
+                    // it unset is valid — Typesense weights fields equally.)
+                    if (mergedParams.query_by_weights) {
+                        const weights = String(mergedParams.query_by_weights)
+                            .split(',')
+                            .map(w => w.trim())
+                            .filter(Boolean);
+                        weights.push('1');
+                        mergedParams.query_by_weights = weights.join(',');
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Adds `apps/playground` — a standalone Vite app for developing the search UI without a Ghost install. It loads the **built** widget the way Ghost does and lets you exercise every feature interactively.

`npm run dev` orchestrates everything ([`scripts/dev.js`](apps/playground/scripts/dev.js)): starts a real Typesense in Docker → waits for health → seeds sample posts → launches Vite. It **requires Docker and fails with a clear message** if it's unavailable, pointing at `npm run dev:mock` (Vite only, backed by an in-process mock for zero-setup offline use).

- **Loads the real bundle:** a dev-server middleware serves `packages/search-ui/dist/search.min.js` at `/search.min.js` with no module transform (the production load shape), with a clear "build it first" message if missing.
- **Real semantic search:** the seeded collection mirrors the indexer's schema (including the nested `tags.name`/`tags.slug` the widget queries) and includes an embedding field, so the semantic toggle runs a genuine hybrid query. If the model can't initialize, the seed falls back to lexical-only and the playground disables the Semantic toggle and explains why in the on-page log.
- **Controls** for template (list/grid), theme, suggestions, facets, semantic search, and analytics. Applying persists config and reloads so the single-instance widget picks it up.
- **Observability:** analytics events and the queries they carry are shown in an on-page log (via `navigator.sendBeacon` intercept).

## Also: a search-UI bugfix the playground surfaced

With semantic search enabled, the widget appended the embedding field to `query_by` but left `query_by_weights` unchanged, which Typesense rejects:

> Number of weights in `query_by_weights` does not match number of `query_by` fields.

Fixed in `packages/search-ui/src/search.js` (appends a matching weight), with new tests in the search-ui suite covering the semantic `query_by` / `query_by_weights` shaping.

## Acceptance criteria (all met)

- [x] Private Vite workspace app with `dev` / `build` / `preview`
- [x] Loads the built bundle (not source via Vite), clear error if unbuilt
- [x] Controls for theme, template, suggestions, facets, semantic, analytics
- [x] Analytics events + queries visible in an on-page log
- [x] Runs without Ghost (offline mock and/or Docker Typesense)
- [x] Private; doesn't break root build / test / lint / typecheck
- [x] README covers running it and pointing at a real Typesense

## Verification

- Full root gates pass: `lint` (5/5), `typecheck` (7/7), `test` (11/11; search-ui now 37 tests), `build` (6/6).
- Verified end to end against a real Docker Typesense: seed creates the embedding collection (model downloads + caches), and both lexical and **semantic** queries return correctly ranked results (`vector_distance`/`rank_fusion_score` confirm the vector half ran — e.g. "cultivating plants" surfaces the gardening posts with no keyword overlap).
- The offline mock and the "bundle not built" path were verified too.

> Note: the playground itself is a manual dev tool with no unit tests; the widget behaviour it drives is covered by `packages/search-ui`.

close #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive search UI playground with configurable controls for layout, theme, facets, suggestions, and semantic search options.
  * Introduced offline mock search mode for local testing without external dependencies.
  * Improved semantic search functionality with proper embedding field weight configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->