### PR TITLE
feat: index members-only and paid content, redacted (close #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ Set `semanticSearch: true` in your search config — see the [search-ui semantic
 - **Memory.** Vector fields meaningfully increase a collection's RAM footprint. Benchmark on a representative slice of your content before enabling it for a large blog.
 - **Index time.** Generating embeddings adds latency to syncing. Built-in models add CPU time on the Typesense server; external providers add per-document API calls (and their cost). Large initial syncs take noticeably longer than lexical-only indexing.
 
+## Members-only content
+
+**By default, only public published posts are indexed.** Members-only and paid posts are skipped entirely, so a blog that publishes mostly gated content will have a near-empty search index.
+
+You can opt in to indexing gated posts as **redacted** documents — discoverable in search, but without exposing the protected body. Set `indexGatedContent` on the collection config:
+
+```json
+{
+  "collection": {
+    "name": "ghost",
+    "indexGatedContent": true
+  }
+}
+```
+
+With it enabled:
+
+- Non-public posts (`members`, `paid`, tier-restricted) are indexed with their **title, excerpt, URL, tags, and feature image**, plus a `visibility` field.
+- The searchable text is limited to the public excerpt (falling back to the title). The post's body is **never read or indexed** — this package uses Ghost's Content API, which only ever returns the public preview for gated posts, and the indexer ignores the body regardless. There is no protected text in the index to leak.
+- The search UI marks these results with a "members only" badge (see the [search-ui README](packages/search-ui/README.md#members-only-results)), turning gated posts into discoverable lead magnets.
+
+For real-time updates, set `INDEX_GATED_CONTENT=true` on the webhook handler to mirror this behaviour.
+
 ## Packages
 
 | Package | Description |

--- a/apps/playground/scripts/seed.js
+++ b/apps/playground/scripts/seed.js
@@ -45,7 +45,9 @@ const schema = {
     { name: 'tags', type: 'string[]', facet: true, optional: true },
     { name: 'tags.name', type: 'string[]', facet: true, optional: true },
     { name: 'tags.slug', type: 'string[]', facet: true, optional: true },
-    { name: 'authors', type: 'string[]', facet: true, optional: true }
+    { name: 'authors', type: 'string[]', facet: true, optional: true },
+    // Lets the widget show the members-only badge on gated results.
+    { name: 'visibility', type: 'string', facet: true, optional: true }
   ]
 };
 
@@ -104,6 +106,29 @@ async function createCollection() {
   return false;
 }
 
+// Creating an embedding collection returns as soon as the schema is registered,
+// but the model keeps loading asynchronously — importing documents before it is
+// ready fails with a 404 / "not ready". Poll a trivial search until it
+// succeeds so the import doesn't race the model.
+async function waitForModelReady() {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  for (let attempt = 1; attempt <= 30; attempt++) {
+    try {
+      await client.collections(COLLECTION).documents().search({ q: '*', query_by: 'embedding' });
+      return; // model is serving queries
+    } catch (err) {
+      const msg = String(err?.message || err).toLowerCase();
+      // 404 / not-ready while the model loads — keep waiting. Anything else is
+      // a real error worth surfacing.
+      if (!(msg.includes('not found') || msg.includes('not ready') || msg.includes('404'))) {
+        return;
+      }
+      if (attempt === 1) console.log('▸ Waiting for the embedding model to finish loading …');
+      await sleep(2000);
+    }
+  }
+}
+
 async function main() {
   try {
     await client.collections(COLLECTION).delete();
@@ -112,19 +137,29 @@ async function main() {
     // Collection didn't exist yet — fine.
   }
 
-  await createCollection();
+  const embeddingEnabled = await createCollection();
+  if (embeddingEnabled) {
+    await waitForModelReady();
+  }
 
   const slugify = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  const documents = POSTS.map(({ feature_image, tags = [], ...rest }) => ({
-    ...rest,
-    tags,
-    // The widget's default query_by/facets use the nested fields, so provide
-    // them the way packages/core does.
-    'tags.name': tags,
-    'tags.slug': tags.map(slugify),
-    // Typesense rejects null for an optional string; omit instead.
-    ...(feature_image ? { feature_image } : {})
-  }));
+  const documents = POSTS.map(({ feature_image, tags = [], plaintext, ...rest }) => {
+    const visibility = rest.visibility || 'public';
+    return {
+      ...rest,
+      visibility,
+      // Redact gated posts the way packages/core does: the protected body never
+      // reaches Typesense — only the excerpt (the public teaser) is searchable.
+      plaintext: visibility === 'public' ? plaintext : rest.excerpt || rest.title || '',
+      tags,
+      // The widget's default query_by/facets use the nested fields, so provide
+      // them the way packages/core does.
+      'tags.name': tags,
+      'tags.slug': tags.map(slugify),
+      // Typesense rejects null for an optional string; omit instead.
+      ...(feature_image ? { feature_image } : {})
+    };
+  });
 
   const results = await client.collections(COLLECTION).documents().import(documents, { action: 'upsert' });
   const failed = results.filter((r) => !r.success);

--- a/apps/playground/src/mock.js
+++ b/apps/playground/src/mock.js
@@ -123,11 +123,13 @@ function highlight(text, q) {
 // never returned — the same guarantee the real indexer provides.
 function toIndexedDoc(post) {
   const visibility = post.visibility || 'public';
-  const { plaintext, ...rest } = post;
+  const { plaintext, html, ...rest } = post;
   if (visibility === 'public') {
-    return { ...rest, plaintext, visibility };
+    return { ...rest, ...(html !== undefined ? { html } : {}), plaintext, visibility };
   }
-  return { ...rest, plaintext: post.excerpt || post.title || '', visibility };
+  // Mirror the core indexer: gated posts carry no body — empty html and
+  // excerpt-only plaintext.
+  return { ...rest, html: '', plaintext: post.excerpt || post.title || '', visibility };
 }
 
 export function mockSearchResponse(params = {}) {

--- a/apps/playground/src/mock.js
+++ b/apps/playground/src/mock.js
@@ -52,6 +52,34 @@ export const POSTS = [
     published_at: 1697000000000,
     tags: ['Ghost', 'Design'],
     authors: ['Sam']
+  },
+  // Gated posts, to demo the members-only badge and redaction. Their plaintext
+  // here represents the protected body — the mock responder and the seed must
+  // never expose it; only the excerpt (the public teaser) is searchable.
+  {
+    id: 'post-5',
+    title: 'Advanced soil chemistry for serious growers',
+    slug: 'advanced-soil-chemistry',
+    url: 'https://demo.example.com/advanced-soil-chemistry/',
+    excerpt: 'The full members-only guide to amending soil pH and nutrients.',
+    plaintext: 'MEMBERS_ONLY_BODY: detailed N-P-K ratios, chelated micronutrients, and lab testing protocols.',
+    feature_image: 'https://images.unsplash.com/photo-1466692476868-aef1dfb1e735?w=1200&q=80',
+    published_at: 1696000000000,
+    tags: ['Gardening'],
+    authors: ['Jannis'],
+    visibility: 'members'
+  },
+  {
+    id: 'post-6',
+    title: 'The complete Ghost performance course',
+    slug: 'ghost-performance-course',
+    url: 'https://demo.example.com/ghost-performance-course/',
+    excerpt: 'A paid deep-dive into squeezing every millisecond out of Ghost.',
+    plaintext: 'PAID_BODY: CDN tuning, image pipelines, server-timing budgets, and a full audit checklist.',
+    published_at: 1695000000000,
+    tags: ['Ghost', 'Design'],
+    authors: ['Sam'],
+    visibility: 'paid'
   }
 ];
 
@@ -89,12 +117,29 @@ function highlight(text, q) {
   return { snippet };
 }
 
+// The indexed representation of a post, mirroring what packages/core writes to
+// Typesense. Public posts keep their plaintext; gated (members/paid) posts are
+// redacted to the excerpt only, so their protected body is never searchable and
+// never returned — the same guarantee the real indexer provides.
+function toIndexedDoc(post) {
+  const visibility = post.visibility || 'public';
+  const { plaintext, ...rest } = post;
+  if (visibility === 'public') {
+    return { ...rest, plaintext, visibility };
+  }
+  return { ...rest, plaintext: post.excerpt || post.title || '', visibility };
+}
+
 export function mockSearchResponse(params = {}) {
   const q = (params.q || '').trim();
   const filters = parseFilterBy(params.filter_by);
   const facetBy = (params.facet_by || '').split(',').map((f) => f.trim()).filter(Boolean);
 
-  const filtered = POSTS.filter((p) => {
+  // Search against the redacted index view, never the raw posts, so a gated
+  // post's protected body is not even matchable.
+  const indexed = POSTS.map(toIndexedDoc);
+
+  const filtered = indexed.filter((p) => {
     if (!matchesFilters(p, filters)) return false;
     if (!q || q === '*') return true;
     const haystack = `${p.title} ${p.excerpt} ${p.plaintext} ${p.tags.join(' ')}`.toLowerCase();

--- a/apps/webhook-handler/src/handler.ts
+++ b/apps/webhook-handler/src/handler.ts
@@ -10,7 +10,10 @@ const EnvSchema = z.object({
   TYPESENSE_HOST: z.string().min(1),
   TYPESENSE_API_KEY: z.string().min(1),
   COLLECTION_NAME: z.string().min(1).default('posts'),
-  WEBHOOK_SECRET: z.string().min(1)
+  WEBHOOK_SECRET: z.string().min(1),
+  // Opt-in: set to "true" to index members-only / paid posts as redacted
+  // documents. Defaults off, so only public posts are indexed.
+  INDEX_GATED_CONTENT: z.string().optional()
 });
 
 // Ghost webhook payload schema
@@ -82,6 +85,9 @@ const handler: Handler = async (event) => {
       env.TYPESENSE_API_KEY,
       env.COLLECTION_NAME
     );
+    // Opt-in: index members-only / paid posts as redacted documents.
+    const indexGatedContent = env.INDEX_GATED_CONTENT === 'true';
+    config.collection.indexGatedContent = indexGatedContent;
     console.log('⚙️  Configuration loaded');
 
     // Initialize manager
@@ -112,7 +118,12 @@ const handler: Handler = async (event) => {
       const { id, status, visibility, title } = post.current;
       console.log(`📄 Processing post: "${title}" (${id})`);
       
-      if (status === 'published' && visibility === 'public') {
+      // Index public posts always; index gated posts only when opted in (core
+      // redacts them). indexPost itself removes a gated post when the flag is
+      // off, so anything published is safe to route through it here.
+      const indexable = status === 'published' && (visibility === 'public' || indexGatedContent);
+
+      if (indexable) {
         console.log('📝 Indexing published post');
         await manager.indexPost(id);
         console.log('✨ Post indexed successfully');

--- a/packages/config/src/__tests__/index.test.ts
+++ b/packages/config/src/__tests__/index.test.ts
@@ -212,3 +212,26 @@ describe('Semantic search field', () => {
     ).toThrow();
   });
 });
+
+describe('Gated content config', () => {
+  const base = {
+    ghost: { url: 'https://example.com', key: 'valid-key', version: 'v5.0' },
+    typesense: { nodes: [{ host: 'localhost', port: 8108, protocol: 'http' }], apiKey: 'valid-key' }
+  };
+
+  it('treats a missing indexGatedContent as off (falsy)', () => {
+    const config = validateConfig({ ...base, collection: { name: 'posts' } });
+    expect(config.collection.indexGatedContent).toBeFalsy();
+  });
+
+  it('accepts indexGatedContent: true', () => {
+    const config = validateConfig({ ...base, collection: { name: 'posts', indexGatedContent: true } });
+    expect(config.collection.indexGatedContent).toBe(true);
+  });
+
+  it('includes an optional visibility field in the default schema', () => {
+    const field = DEFAULT_COLLECTION_FIELDS.find((f) => f.name === 'visibility');
+    expect(field).toBeDefined();
+    expect(field?.optional).toBe(true);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -109,7 +109,10 @@ export const DEFAULT_COLLECTION_FIELDS: CollectionField[] = [
   { name: 'tags', type: 'string[]', facet: true, optional: true },
   { name: 'tags.name', type: 'string[]', index: true, facet: true, optional: true },
   { name: 'tags.slug', type: 'string[]', index: true, facet: true, optional: true },
-  { name: 'authors', type: 'string[]', facet: true, optional: true }
+  { name: 'authors', type: 'string[]', facet: true, optional: true },
+  // Ghost visibility ('public', 'members', 'paid', ...). Optional so existing
+  // collections are unaffected; lets the front end distinguish gated results.
+  { name: 'visibility', type: 'string', facet: true, optional: true }
 ];
 
 /**
@@ -147,7 +150,13 @@ export const CollectionConfigSchema = z.object({
       // Convert map back to array, keeping any additional custom fields
       return Array.from(fieldMap.values());
     }),
-  default_sorting_field: z.string().optional()
+  default_sorting_field: z.string().optional(),
+  // Opt-in: when true, members-only / paid posts are indexed as redacted
+  // documents (title, excerpt, preview, metadata — never the protected body).
+  // Omitted/undefined is treated as false, so only public published content is
+  // indexed by default. Left optional (no schema default) so existing config
+  // objects remain valid without this key.
+  indexGatedContent: z.boolean().optional()
 });
 
 /**

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -212,3 +212,80 @@ describe('GhostTypesenseManager — semantic search', () => {
     expect('embedding' in document).toBe(false);
   });
 });
+
+describe('GhostTypesenseManager — gated content redaction', () => {
+  const baseConfig: Config = {
+    ghost: { url: 'https://test.com', key: 'test-key', version: 'v5.0' },
+    typesense: { nodes: [{ host: 'localhost', port: 8108, protocol: 'http' }], apiKey: 'test-key' },
+    collection: {
+      name: 'test-collection',
+      fields: [
+        { name: 'id', type: 'string', optional: false },
+        { name: 'title', type: 'string', optional: false },
+        { name: 'slug', type: 'string', optional: false },
+        { name: 'html', type: 'string', optional: true },
+        { name: 'excerpt', type: 'string', optional: true },
+        { name: 'published_at', type: 'int64', optional: false },
+        { name: 'updated_at', type: 'int64', optional: false }
+      ]
+    }
+  };
+
+  // A members-only post whose body, if ever indexed, would contain this
+  // sentinel. The redaction must guarantee it never appears in the document.
+  const gatedPost = {
+    id: 'gated-1',
+    title: 'Members deep dive',
+    slug: 'members-deep-dive',
+    excerpt: 'A teaser anyone can read.',
+    html: '<p>SECRET_PROTECTED_BODY that must never be indexed.</p>',
+    plaintext: 'SECRET_PROTECTED_BODY that must never be indexed.',
+    visibility: 'members',
+    published_at: '2024-02-09T19:00:00.000Z',
+    updated_at: '2024-02-09T19:00:00.000Z',
+    tags: [{ name: 'Premium', slug: 'premium' }],
+    authors: [{ name: 'Author' }]
+  };
+
+  // transformPost is private; reach it for a focused unit test of redaction.
+  function transform(manager: GhostTypesenseManager, post: unknown) {
+    return (manager as unknown as { transformPost: (p: unknown) => Record<string, unknown> }).transformPost(post);
+  }
+
+  it('redacts a gated post: no protected body, preview-only plaintext, visibility set', () => {
+    const manager = new GhostTypesenseManager({
+      ...baseConfig,
+      collection: { ...baseConfig.collection, indexGatedContent: true }
+    });
+    const doc = transform(manager, gatedPost);
+
+    expect(doc.visibility).toBe('members');
+    expect(doc.html).toBe('');
+    // The searchable text is the public excerpt, never the protected body.
+    expect(doc.plaintext).toBe('A teaser anyone can read.');
+    const serialized = JSON.stringify(doc);
+    expect(serialized).not.toContain('SECRET_PROTECTED_BODY');
+    // Public metadata is still indexed so the result is useful/discoverable.
+    expect(doc.tags).toEqual(['Premium']);
+  });
+
+  it('falls back to the title when a gated post has no excerpt', () => {
+    const manager = new GhostTypesenseManager({
+      ...baseConfig,
+      collection: { ...baseConfig.collection, indexGatedContent: true }
+    });
+    const doc = transform(manager, { ...gatedPost, excerpt: '' });
+    expect(doc.plaintext).toBe('Members deep dive');
+  });
+
+  it('indexes public posts in full with visibility "public"', () => {
+    const manager = new GhostTypesenseManager(baseConfig);
+    const doc = transform(manager, {
+      id: 'pub-1', title: 'Public', slug: 'public',
+      html: '<p>Readable body</p>', excerpt: 'x', visibility: 'public',
+      published_at: '2024-02-09T19:00:00.000Z', updated_at: '2024-02-09T19:00:00.000Z'
+    });
+    expect(doc.visibility).toBe('public');
+    expect(String(doc.plaintext)).toContain('Readable body');
+  });
+});

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -33,22 +33,43 @@ vi.mock('@ts-ghost/content-api', () => {
             })
           })
         }),
-        read: () => ({
+        // `read` returns a public post by default, or a members-only post when
+        // asked for the gated id — so the gated indexPost paths can be tested.
+        read: ({ id }: { id: string }) => ({
           include: () => ({
-            fetch: async () => ({
-              success: true,
-              data: {
-                id: 'test-post-1',
-                title: 'Test Post 1',
-                slug: 'test-post-1',
-                html: '<p>Test content</p>',
-                excerpt: 'Test excerpt',
-                published_at: '2024-02-09T19:00:00.000Z',
-                updated_at: '2024-02-09T19:00:00.000Z',
-                tags: [{ name: 'test-tag' }],
-                authors: [{ name: 'Test Author' }]
-              }
-            })
+            fetch: async () =>
+              id === 'gated-post-1'
+                ? {
+                    success: true,
+                    data: {
+                      id: 'gated-post-1',
+                      title: 'Members Post',
+                      slug: 'members-post',
+                      html: '<p>SECRET_PROTECTED_BODY for members only.</p>',
+                      plaintext: 'SECRET_PROTECTED_BODY for members only.',
+                      excerpt: 'A public teaser.',
+                      visibility: 'members',
+                      published_at: '2024-02-09T19:00:00.000Z',
+                      updated_at: '2024-02-09T19:00:00.000Z',
+                      tags: [{ name: 'premium', slug: 'premium' }],
+                      authors: [{ name: 'Test Author' }]
+                    }
+                  }
+                : {
+                    success: true,
+                    data: {
+                      id: 'test-post-1',
+                      title: 'Test Post 1',
+                      slug: 'test-post-1',
+                      html: '<p>Test content</p>',
+                      excerpt: 'Test excerpt',
+                      visibility: 'public',
+                      published_at: '2024-02-09T19:00:00.000Z',
+                      updated_at: '2024-02-09T19:00:00.000Z',
+                      tags: [{ name: 'test-tag' }],
+                      authors: [{ name: 'Test Author' }]
+                    }
+                  }
           })
         })
       }
@@ -287,5 +308,44 @@ describe('GhostTypesenseManager — gated content redaction', () => {
     });
     expect(doc.visibility).toBe('public');
     expect(String(doc.plaintext)).toContain('Readable body');
+  });
+
+  // Integration through indexPost (the path the webhook uses), driving the
+  // mocked Ghost API's gated post.
+  describe('indexPost', () => {
+    beforeEach(() => {
+      mockDocuments.upsert.mockClear();
+      mockDocuments.delete.mockClear();
+    });
+
+    it('removes a gated post (does not index it) when the flag is off', async () => {
+      const manager = new GhostTypesenseManager(baseConfig); // indexGatedContent undefined → off
+      await manager.indexPost('gated-post-1');
+
+      expect(mockDocuments.upsert).not.toHaveBeenCalled();
+      expect(mockDocuments.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('indexes a gated post as a redacted document when the flag is on', async () => {
+      const manager = new GhostTypesenseManager({
+        ...baseConfig,
+        collection: { ...baseConfig.collection, indexGatedContent: true }
+      });
+      await manager.indexPost('gated-post-1');
+
+      expect(mockDocuments.upsert).toHaveBeenCalledTimes(1);
+      const doc = mockDocuments.upsert.mock.calls[0]![0] as Record<string, unknown>;
+      expect(doc.visibility).toBe('members');
+      expect(doc.html).toBe('');
+      expect(JSON.stringify(doc)).not.toContain('SECRET_PROTECTED_BODY');
+    });
+
+    it('indexes a public post normally regardless of the flag', async () => {
+      const manager = new GhostTypesenseManager(baseConfig);
+      await manager.indexPost('test-post-1');
+
+      expect(mockDocuments.upsert).toHaveBeenCalledTimes(1);
+      expect(mockDocuments.delete).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export interface Post {
   feature_image?: string;
   published_at: number;
   updated_at: number;
+  visibility?: string;
   'tags.name'?: string[];
   'tags.slug'?: string[];
   authors?: string[];
@@ -86,15 +87,80 @@ export class GhostTypesenseManager {
   }
 
   /**
+   * Copy tags, authors, and feature image onto a transformed document. Shared
+   * by the public and redacted paths — this is all public metadata, safe to
+   * index regardless of visibility.
+   * @private
+   */
+  private applyPostMetadata(post: GhostPost, transformed: Post): void {
+    if (post.feature_image) {
+      transformed.feature_image = post.feature_image;
+    }
+
+    const tags = post.tags;
+    if (tags && Array.isArray(tags) && tags.length > 0) {
+      transformed['tags.name'] = tags.map((tag: { name: string }) => tag.name);
+      transformed['tags.slug'] = tags.map((tag: { slug: string }) => tag.slug);
+      transformed.tags = tags.map((tag: { name: string }) => tag.name);
+    }
+
+    const authors = post.authors;
+    if (authors && Array.isArray(authors) && authors.length > 0) {
+      transformed.authors = authors.map((author: { name: string }) => author.name);
+    }
+  }
+
+  /**
+   * Build a redacted document for a non-public (members-only / paid) post. The
+   * post's html and full plaintext are deliberately never read here, so no
+   * protected body text can enter the index. Searchable text is limited to the
+   * excerpt (the public teaser) and falls back to the title.
+   * @private
+   */
+  private buildRedactedPost(post: GhostPost, visibility: string): Post {
+    const excerpt = post.excerpt || '';
+    const preview = excerpt || post.title || '';
+
+    const transformed: Post = {
+      id: post.id,
+      title: post.title,
+      slug: post.slug,
+      url: post.url || `${this.config.ghost.url}/${post.slug}/`,
+      html: '',
+      plaintext: preview,
+      excerpt,
+      published_at: new Date(post.published_at || Date.now()).getTime(),
+      updated_at: new Date(post.updated_at || Date.now()).getTime(),
+      visibility
+    };
+
+    this.applyPostMetadata(post, transformed);
+    return transformed;
+  }
+
+  /**
    * Transform a Ghost post into the format expected by Typesense
    */
   private transformPost(post: GhostPost): Post {
     console.log('Transforming post:', post.id, post.title);
 
+    const visibility = (post as { visibility?: string }).visibility || 'public';
+    const isGated = visibility !== 'public';
+
+    // Gated (members-only / paid) posts are indexed as redacted documents: we
+    // never read their html/plaintext — even though the Content API already
+    // returns only the public preview for them, the body is ignored here by
+    // construction so no protected text can ever enter the index. The
+    // searchable text is limited to the excerpt (the public teaser), falling
+    // back to the title.
+    if (isGated) {
+      return this.buildRedactedPost(post, visibility);
+    }
+
     // Ensure we have plaintext content
     let plaintext = post.plaintext || '';
 
-    // Always try to enhance/improve plaintext extraction from HTML 
+    // Always try to enhance/improve plaintext extraction from HTML
     // even if plaintext already exists
     if (post.html) {
       // Use a more comprehensive approach to extract text including from links and special formatting
@@ -140,27 +206,11 @@ export class GhostTypesenseManager {
       plaintext: plaintext,
       excerpt: post.excerpt || '',
       published_at: new Date(post.published_at || Date.now()).getTime(),
-      updated_at: new Date(post.updated_at || Date.now()).getTime()
+      updated_at: new Date(post.updated_at || Date.now()).getTime(),
+      visibility: 'public'
     };
 
-    if (post.feature_image) {
-      transformed.feature_image = post.feature_image;
-    }
-
-    const tags = post.tags;
-    if (tags && Array.isArray(tags) && tags.length > 0) {
-      // Use dot notation for nested tag fields
-      transformed['tags.name'] = tags.map((tag: { name: string }) => tag.name);
-      transformed['tags.slug'] = tags.map((tag: { slug: string }) => tag.slug);
-      
-      // Add the standard tags field that Typesense expects as string[]
-      transformed.tags = tags.map((tag: { name: string }) => tag.name);
-    }
-
-    const authors = post.authors;
-    if (authors && Array.isArray(authors) && authors.length > 0) {
-      transformed.authors = authors.map((author: { name: string }) => author.name);
-    }
+    this.applyPostMetadata(post, transformed);
 
     // Add any additional fields specified in the config
     // Only add fields that haven't already been transformed to avoid overriding custom transformations
@@ -240,8 +290,14 @@ export class GhostTypesenseManager {
       allPosts = allPosts.concat(pageResponse.data);
     }
 
-    console.log(`Found ${allPosts.length} posts to index`);
-    const documents = allPosts.map((post) => this.transformPost(post));
+    // Unless gated indexing is opted into, drop non-public posts so only
+    // public published content is indexed (the default behaviour).
+    const postsToIndex = this.config.collection.indexGatedContent
+      ? allPosts
+      : allPosts.filter((post) => ((post as { visibility?: string }).visibility || 'public') === 'public');
+
+    console.log(`Found ${postsToIndex.length} posts to index (of ${allPosts.length} fetched)`);
+    const documents = postsToIndex.map((post) => this.transformPost(post));
 
     // Use batched bulk import for better performance and reliability
     await this.indexDocumentsBatched(documents);
@@ -457,8 +513,18 @@ export class GhostTypesenseManager {
       throw new Error(`Failed to fetch post ${postId} from Ghost`);
     }
 
-    const document = this.transformPost(post.data);
+    const visibility = (post.data as { visibility?: string }).visibility || 'public';
     const collection = this.typesense.collections(this.collectionName);
+
+    // Respect the opt-in: with gated indexing off, a non-public post must not
+    // be indexed. Remove any existing document (e.g. a post that just turned
+    // members-only) rather than upserting it.
+    if (visibility !== 'public' && !this.config.collection.indexGatedContent) {
+      await collection.documents().delete({ filter_by: `id:${postId}` }).catch(() => {});
+      return;
+    }
+
+    const document = this.transformPost(post.data);
     await collection.documents().upsert(document);
   }
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -280,6 +280,14 @@ Behaviour:
 - Selections can be cleared individually (toggling a chip off) or all at once via the **Clear filters** button.
 - A publisher-provided `typesenseSearchParams.filter_by` is **preserved**: facet selections are AND-ed with it rather than overwriting it.
 
+## Members-only results
+
+When the index includes gated (members-only / paid) posts — see [indexing members-only content](../../README.md#members-only-content) on the indexing side — the widget marks those results with a small **"members only"** badge. No widget configuration is needed; it keys off the `visibility` field on each result and requests that field automatically.
+
+Gated results carry a `mp-search-result-gated` class and a `data-gated="<visibility>"` attribute on the result link, so you can style them or wire clicks to a membership/upsell flow with your own theme code. The badge text is translatable via the `membersLabel` / `ariaMembersLabel` keys (see [Internationalization](#internationalization-i18n)).
+
+Because gated posts are indexed as redacted documents (excerpt/preview only), there is no protected body text in the results to expose.
+
 ## Semantic search
 
 Semantic (hybrid) search is **opt-in and disabled by default**. By default the widget runs purely lexical queries — keyword matching with prefix matching, optional typo tolerance, and field weighting.
@@ -438,6 +446,8 @@ window.__MP_SEARCH_CONFIG__ = {
 | `ariaModalLabel` | "Search" | ARIA label for modal |
 | `ariaFacetsLabel` | "Filters" | ARIA label for the facet filter group |
 | `clearFiltersLabel` | "Clear filters" | Label for the button that clears active facet filters |
+| `membersLabel` | "Members only" | Badge text on gated (members-only / paid) results |
+| `ariaMembersLabel` | "Members-only content" | ARIA label for the members-only badge |
 | `untitledPost` | "Untitled" | Fallback for posts without titles |
 
 ### Example Translations

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -103,11 +103,25 @@ describe('getSearchParameters — analytics include_fields', () => {
     expect(fields).toContain('id');
   });
 
-  it('does not touch include_fields when analytics is disabled', () => {
+  it('does not add id to include_fields when analytics is disabled', () => {
     const el = mountWithConfig({
       typesenseSearchParams: { include_fields: 'title,url' }
     });
-    expect(el.getSearchParameters().include_fields).toBe('title,url');
+    expect(el.getSearchParameters().include_fields.split(',')).not.toContain('id');
+  });
+});
+
+describe('getSearchParameters — visibility include_fields', () => {
+  it('preserves visibility when a host overrides include_fields (for the gated badge)', () => {
+    const el = mountWithConfig({
+      typesenseSearchParams: { include_fields: 'title,url' }
+    });
+    expect(el.getSearchParameters().include_fields.split(',')).toContain('visibility');
+  });
+
+  it('keeps visibility in the default include_fields', () => {
+    const el = mountWithConfig();
+    expect(el.getSearchParameters().include_fields.split(',')).toContain('visibility');
   });
 });
 

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -895,6 +895,20 @@ import Typesense from 'typesense';
                 }
             }
 
+            // The members-only badge keys off `visibility`, so keep it in the
+            // returned fields even if a host overrode include_fields. Harmless
+            // for public-only collections (the field is simply absent there).
+            {
+                const fields = String(mergedParams.include_fields || '')
+                    .split(',')
+                    .map(f => f.trim())
+                    .filter(Boolean);
+                if (fields.length && !fields.includes('visibility')) {
+                    fields.push('visibility');
+                    mergedParams.include_fields = fields.join(',');
+                }
+            }
+
             // The grid template shows the post's feature image, so make sure it
             // is returned. Only added in grid mode, leaving the list/default
             // query's returned fields unchanged.

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -101,6 +101,8 @@ import Typesense from 'typesense';
                 ariaModalLabel: 'Search',
                 ariaFacetsLabel: 'Filters',
                 clearFiltersLabel: 'Clear filters',
+                membersLabel: 'Members only',
+                ariaMembersLabel: 'Members-only content',
                 untitledPost: 'Untitled'
             };
         }
@@ -786,19 +788,25 @@ import Typesense from 'typesense';
                         ? this.toRelativeUrl(hit.document.url)
                         : (hit.document.url || '#');
 
+                    // A non-public (members-only / paid) result, surfaced via
+                    // the redacted index documents. Flagged so it can be styled
+                    // and routed to a membership flow.
+                    const isGated = !!hit.document.visibility && hit.document.visibility !== 'public';
+
                     // The link wrapper (class + data attributes + aria-label) is
                     // shared by both templates, so keyboard navigation, click
                     // handling, and analytics behave identically — only the
                     // inner article markup differs.
                     return `
                         <a href="${resultUrl}"
-                            class="${CSS_PREFIX}-result-link"
+                            class="${CSS_PREFIX}-result-link${isGated ? ` ${CSS_PREFIX}-result-gated` : ''}"
                             data-result-id="${this.escapeHtmlAttr(hit.document.id)}"
                             data-result-position="${index}"
+                            ${isGated ? `data-gated="${this.escapeHtmlAttr(hit.document.visibility)}"` : ''}
                             aria-label="${title.replace(/<[^>]*>/g, '')}">
                             ${this.config.template === 'grid'
-                                ? this.renderGridCard(hit, title, excerpt)
-                                : this.renderListItem(title, excerpt)}
+                                ? this.renderGridCard(hit, title, excerpt, isGated)
+                                : this.renderListItem(title, excerpt, isGated)}
                         </a>
                     `;
                 }).join('');
@@ -846,7 +854,7 @@ import Typesense from 'typesense';
                 query_by_weights: weights.join(','),
                 highlight_full_fields: highlightFields.join(','),
                 highlight_affix_num_tokens: 30,
-                include_fields: 'id,title,url,excerpt,plaintext,published_at,tags',
+                include_fields: 'id,title,url,excerpt,plaintext,published_at,tags,visibility',
                 typo_tolerance: false,
                 num_typos: 0,
                 prefix: true,
@@ -1086,12 +1094,20 @@ import Typesense from 'typesense';
             }
         }
 
+        // A small lock badge shown on gated (members-only / paid) results.
+        gatedBadge(isGated) {
+            if (!isGated) return '';
+            return `<span class="${CSS_PREFIX}-gated-badge" aria-label="${this.t('ariaMembersLabel')}">
+                        <span aria-hidden="true">🔒</span> ${this.t('membersLabel')}
+                    </span>`;
+        }
+
         // Default list layout: title + excerpt. `title` and `excerpt` already
         // contain (Typesense-escaped) highlight markup.
-        renderListItem(title, excerpt) {
+        renderListItem(title, excerpt, isGated) {
             return `
                 <article class="${CSS_PREFIX}-result-item" role="article">
-                    <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}</h3>
+                    <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(isGated)}</h3>
                     <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
                 </article>
             `;
@@ -1101,7 +1117,7 @@ import Typesense from 'typesense';
         // image is decorative (the link already carries the title via
         // aria-label); when a post has no feature_image a styled placeholder is
         // shown instead of a broken image.
-        renderGridCard(hit, title, excerpt) {
+        renderGridCard(hit, title, excerpt, isGated) {
             const featureImage = hit.document.feature_image;
             const imageHtml = featureImage
                 ? `<img class="${CSS_PREFIX}-card-image" src="${this.escapeHtmlAttr(featureImage)}" alt="" loading="lazy" />`
@@ -1118,7 +1134,7 @@ import Typesense from 'typesense';
                 <article class="${CSS_PREFIX}-result-item ${CSS_PREFIX}-card" role="article">
                     ${imageHtml}
                     <div class="${CSS_PREFIX}-card-body">
-                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}</h3>
+                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(isGated)}</h3>
                         <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
                         ${tagsHtml}
                     </div>

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -507,6 +507,23 @@
     word-break: break-word;
 }
 
+/* Members-only / paid result badge */
+.mp-search-gated-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(0.25 * var(--mp-rem));
+    margin-left: calc(0.5 * var(--mp-rem));
+    padding: calc(0.0625 * var(--mp-rem)) calc(0.4 * var(--mp-rem));
+    border-radius: 999px;
+    background: var(--color-result-hover);
+    color: var(--color-text-secondary);
+    font-size: calc(0.6875 * var(--mp-rem));
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
 /* Grid (card) layout */
 .mp-search-hits-list.mp-search-grid {
     display: grid;


### PR DESCRIPTION
## Summary

By default only public posts are indexed, so a blog that publishes mostly gated content has a near-empty search index. This adds an **opt-in** to index members-only and paid posts as **redacted** documents — discoverable in search, never exposing the protected body.

- **`config`**: optional `collection.indexGatedContent` flag (default off) + an optional `visibility` field in the default schema.
- **`core`**: `transformPost` branches on `post.visibility`. Public posts index as before (now carrying `visibility: "public"`). Non-public posts go through `buildRedactedPost`, which **never reads the post's html/plaintext** — searchable text is the excerpt (falling back to the title), html is emptied. `indexAllPosts` filters out non-public posts when the flag is off; `indexPost` *removes* a now-gated post in that case rather than indexing it.
- **`webhook-handler`**: `INDEX_GATED_CONTENT=true` mirrors the opt-in; indexing routes through core so redaction is centralized.
- **`search-ui`**: gated results get a **"members only"** badge, a `mp-search-result-gated` class, and a `data-gated` attribute so themes can route them to a membership flow. The widget requests the `visibility` field. Two new i18n keys.
- **Docs**: root README documents default-public behaviour + the opt-in flag; search-ui README documents the badge.

## Leak safety

The protected body can never enter the index, guaranteed two ways: this package uses the Ghost **Content API**, which only ever returns the public preview for gated posts, **and** the redaction path ignores the body entirely regardless of input. A unit test asserts a protected-body sentinel never appears in the indexed document.

## Tests & verification

- `config` (14 tests): default falsy, accepts `true`, `visibility` field present.
- `core` (13 tests): `transformPost` redaction (empty html, excerpt-only plaintext, visibility set, leak-guard sentinel) **and** `indexPost` integration through a mocked gated post — flag off → removes (no upsert); flag on → upserts a redacted doc; public indexes normally.
- Playground: members-only + paid sample posts; both the offline mock and the Docker seed redact gated content (excerpt-only, body neither searchable nor returned) and set `visibility`, so the badge is demoable. Verified end-to-end against real Typesense.
- Full root gates pass: lint, typecheck, test, build.

## Scope note

The `visibility` field is now added to the default schema and set on **all** documents (public posts get `visibility: "public"`), and the widget's `include_fields` gains `visibility`. Both are additive/optional and don't change search behaviour for public-only setups.

close #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in indexing for members-only/paid posts as redacted search documents (excerpt/title only) with a recorded visibility field; webhook real-time updates respect this when enabled.
* **UI**
  * Search results show a gated badge and add gated CSS/attributes for accessibility and styling.
* **Documentation**
  * Docs updated to explain gated indexing, redaction behavior, config flag, and webhook requirement.
* **Tests**
  * Added tests covering gated redaction, fallback behaviors, and config handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->