### PR TITLE
chore: release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-06-09
+
+### Fixed
+- **Republished with the correct build artifacts.** The `2.0.0` and `2.0.1` npm
+  packages were published with a stale `dist/` that predated the 2.0 features —
+  the bundle contained no semantic-search or `uiStyle` layout code, and the
+  `palette.min.js` / `discovery.min.js` chunks were missing entirely. As a
+  result, sites updated to `2.0.0`/`2.0.1` silently kept running keyword-only
+  search even with `semanticSearch` enabled. `2.0.2` ships the correctly built
+  bundle (semantic/hybrid querying, the three `uiStyle` layouts, and the layout
+  chunks). No source changes versus 2.0.0 — this is a build/release fix only.
+  Update to `2.0.2`; `2.0.0` and `2.0.1` should not be used.
+
+## [2.0.1] - 2026-06-09
+
+### Fixed
+- Attempted republish of 2.0.0 to correct the stale build artifacts; the
+  packaged `dist/` was still incorrect. Superseded by 2.0.2 — do not use.
+
 ## [2.0.0] - 2026-06-08
 
 A major release that turns the search UI from a single modal into a configurable

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "CLI tool for managing Ghost content in Typesense",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,8 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.0",
-    "@magicpages/ghost-typesense-core": "^2.0.0",
+    "@magicpages/ghost-typesense-config": "^2.0.2",
+    "@magicpages/ghost-typesense-core": "^2.0.2",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.0",
-    "@magicpages/ghost-typesense-core": "^2.0.0",
+    "@magicpages/ghost-typesense-config": "^2.0.2",
+    "@magicpages/ghost-typesense-core": "^2.0.2",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -31,11 +31,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.0",
-        "@magicpages/ghost-typesense-core": "^2.0.0",
+        "@magicpages/ghost-typesense-config": "^2.0.2",
+        "@magicpages/ghost-typesense-core": "^2.0.2",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ora": "^8.0.1"
@@ -144,11 +144,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.0",
-        "@magicpages/ghost-typesense-core": "^2.0.0",
+        "@magicpages/ghost-typesense-config": "^2.0.2",
+        "@magicpages/ghost-typesense-core": "^2.0.2",
         "@netlify/functions": "^2.5.1",
         "zod": "^3.22.4"
       },
@@ -9159,7 +9159,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -9241,10 +9241,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.0",
+        "@magicpages/ghost-typesense-config": "^2.0.2",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "typesense": "^1.7.2",
@@ -9323,7 +9323,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -10058,8 +10058,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.0",
-        "@magicpages/ghost-typesense-core": "^2.0.0",
+        "@magicpages/ghost-typesense-config": "^2.0.2",
+        "@magicpages/ghost-typesense-core": "^2.0.2",
         "@types/node": "^20.11.17",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -10166,7 +10166,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.0",
+        "@magicpages/ghost-typesense-config": "^2.0.2",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "@types/node": "^20.11.17",
@@ -10285,8 +10285,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.0",
-        "@magicpages/ghost-typesense-core": "^2.0.0",
+        "@magicpages/ghost-typesense-config": "^2.0.2",
+        "@magicpages/ghost-typesense-core": "^2.0.2",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^20.11.17",
         "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.0",
+    "@magicpages/ghost-typesense-config": "^2.0.2",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
## Summary

Cuts **2.0.2** — a build/release fix. Bumps all published packages to `2.0.2` and documents the release in `CHANGELOG.md`.

**No source changes versus 2.0.0.** The `2.0.0` and `2.0.1` npm packages were published with a stale `dist/` that predated the 2.0 features: the bundle contained no semantic-search or `uiStyle` layout code, and the `palette.min.js` / `discovery.min.js` chunks were missing. As a result, sites that "updated" to 2.0.0/2.0.1 silently kept running keyword-only search even with `semanticSearch` enabled. `2.0.2` ships the correctly built bundle from the 2.0.0 source.

This was caught in production: magicpages.co showed "Current: v2.0.0 • Up to date" in the portal while still serving the old keyword-only bundle, because the published 2.0.0 artifact was the stale build.

## Verification

- Published `2.0.2` npm tarball confirmed correct: `dist/search.min.js` (187308 bytes) contains `vector_query` / `semanticSearch` / `uiStyle`, and both `palette.min.js` + `discovery.min.js` chunks are present.
- jsdelivr already serves the correct 2.0.2 bundle. unpkg had a stale negative-cache for `@2.0.2` right after publish (it self-heals) — note this before triggering the portal update, since the portal fetches unpkg first.

## Files

- `CHANGELOG.md` — `[2.0.2]` and `[2.0.1]` entries
- All 6 published `package.json` — `2.0.2`, `@magicpages/*` cross-deps `^2.0.2`
- `package-lock.json` — version strings only (no dependency-tree changes)

`apps/playground` is private and left at `0.0.0`.

## Test plan

- [ ] Versions consistent across all published packages (`2.0.2`)
- [ ] CHANGELOG renders correctly
- [x] Published 2.0.2 bundle verified to contain semantic + layout code and chunks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Released version 2.0.2 with corrected build artifacts, resolving issues with semantic/hybrid querying and layout styling.
  * Note: Do not use versions 2.0.0 or 2.0.1.

* **Chores**
  * Version bumped to 2.0.2 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->