### PR TITLE
fix(search-ui): prefer fetch(keepalive) over sendBeacon for analytics (close #37)

### DIFF
--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -145,27 +145,47 @@ describe('getSearchParameters — visibility include_fields', () => {
 });
 
 describe('analytics events', () => {
+  let fetchMock;
   let beacon;
   beforeEach(() => {
+    // fetch(keepalive) is the preferred transport (Beacon API is blocked by
+    // content blockers). sendBeacon stays mocked so we can assert it is NOT
+    // used while fetch is available.
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
     beacon = vi.fn(() => true);
     navigator.sendBeacon = beacon;
   });
 
   it('emits one search event for a settled query and dedupes a repeat', () => {
-    const el = mountWithConfig({ analytics: { endpoint: 'https://e/collect', siteId: 's' } });
+    const el = mountWithConfig({ analytics: { endpoint: 'https://e/queries', siteId: 's' } });
 
     el.trackSearch('ghost', 3);
     el.trackSearch('ghost', 3); // same query → suppressed by lastTrackedQuery
     el.trackSearch('themes', 0); // new query, zero results → search + zero_result
 
-    // ghost(search) + themes(search) + themes(zero_result) = 3 beacons; the
+    // ghost(search) + themes(search) + themes(zero_result) = 3 events; the
     // repeated "ghost" call emits nothing.
-    expect(beacon).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('prefers fetch(keepalive) over sendBeacon as the transport', () => {
+    const el = mountWithConfig({ analytics: { endpoint: 'https://e/queries', siteId: 's' } });
+
+    el.trackSearch('ghost', 3);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(beacon).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://e/queries');
+    expect(init.method).toBe('POST');
+    expect(init.keepalive).toBe(true);
   });
 
   it('emits nothing when analytics is not configured', () => {
     const el = mountWithConfig();
     el.trackSearch('ghost', 3);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(beacon).not.toHaveBeenCalled();
   });
 });

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -324,12 +324,15 @@ import Typesense from 'typesense';
             return !!(this.config.analytics && this.config.analytics.endpoint);
         }
 
-        // Send a single analytics event. Uses navigator.sendBeacon so events
-        // survive page navigation (clicking a result unloads the page) and
-        // never block the UI thread, falling back to fetch(keepalive) where
-        // sendBeacon is unavailable. Fully fail-silent: any transport error,
-        // or a non-2xx response, must never surface to the reader or break
-        // search.
+        // Send a single analytics event. Prefers fetch(keepalive): it is
+        // fire-and-forget, survives the page unload triggered by clicking a
+        // result (that is what `keepalive` is for), and — unlike the Beacon
+        // API — is not cancelled wholesale by content blockers. uBlock Origin
+        // and similar block navigator.sendBeacon broadly, regardless of the
+        // destination, so preferring it silently drops events for any reader
+        // running a blocker. sendBeacon is kept only as a fallback for the rare
+        // engine without fetch. Fully fail-silent: any transport error, or a
+        // non-2xx response, must never surface to the reader or break search.
         sendAnalyticsEvent(event) {
             if (!this.isAnalyticsEnabled()) return;
 
@@ -343,22 +346,25 @@ import Typesense from 'typesense';
                 };
                 const body = JSON.stringify(payload);
 
-                // sendBeacon is the preferred transport: it is fire-and-forget
-                // and is not cancelled when the document starts unloading.
-                if (navigator.sendBeacon) {
-                    const blob = new Blob([body], { type: 'application/json' });
-                    if (navigator.sendBeacon(endpoint, blob)) return;
+                // Preferred transport: keepalive fetch completes across page
+                // unloads and isn't caught by Beacon-API filters.
+                if (typeof fetch === 'function') {
+                    fetch(endpoint, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body,
+                        keepalive: true,
+                        mode: 'cors',
+                        credentials: 'omit'
+                    }).catch(() => {});
+                    return;
                 }
 
-                // Fallback for environments without sendBeacon.
-                fetch(endpoint, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body,
-                    keepalive: true,
-                    mode: 'cors',
-                    credentials: 'omit'
-                }).catch(() => {});
+                // Fallback for environments without fetch.
+                if (navigator.sendBeacon) {
+                    const blob = new Blob([body], { type: 'application/json' });
+                    navigator.sendBeacon(endpoint, blob);
+                }
             } catch {
                 // Swallow everything — analytics must never affect search.
             }


### PR DESCRIPTION
## Summary

- Invert the analytics transport preference in `sendAnalyticsEvent`: use `fetch(endpoint, { keepalive: true })` as the **primary** transport, with `navigator.sendBeacon` kept only as a fallback for engines without `fetch`.
- `navigator.sendBeacon` is blocked broadly by content blockers (uBlock Origin and similar) **regardless of destination path**. Preferring it silently dropped analytics events for any reader running a blocker — and the existing `fetch(keepalive)` fallback only ran when `sendBeacon` was *absent*, not when it was present-but-blocked.
- `fetch(..., { keepalive: true })` keeps the fire-and-forget, survives-page-unload behaviour that made `sendBeacon` attractive (that's what `keepalive` is for), but isn't caught by the Beacon-API filters.
- Behaviour is otherwise unchanged: fully fail-silent, JSON body, never blocks search.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (43 tests; added a test asserting `fetch` is preferred over `sendBeacon` and is called with `keepalive: true`)
- [x] `npm run build` clean; `keepalive` present in the built bundle
- [ ] Reviewer: with uBlock Origin enabled, confirm an analytics event now fires (previously the Beacon API call was cancelled)

close #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated analytics event tests to verify fetch-based transport mechanism with keepalive header.

* **Chores**
  * Modified analytics event transport to use fetch with keepalive as primary method, with sendBeacon as fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->