### PR TITLE
chore: release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-06-09
+
+### Fixed
+- **Analytics events were dropped for readers running content blockers.** The
+  emitter preferred `navigator.sendBeacon`, which uBlock Origin and similar
+  block broadly regardless of destination — and the `fetch(keepalive)` fallback
+  only ran when `sendBeacon` was *absent*, not when it was present-but-blocked,
+  so the event was simply lost. `fetch(keepalive)` is now the primary transport
+  (it survives page unload and isn't caught by Beacon-API filters); `sendBeacon`
+  remains only as a fallback for engines without `fetch`. Behaviour is otherwise
+  unchanged — analytics stays fully fail-silent and never affects search.
+
 ## [2.0.2] - 2026-06-09
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "CLI tool for managing Ghost content in Typesense",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,8 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.2",
-    "@magicpages/ghost-typesense-core": "^2.0.2",
+    "@magicpages/ghost-typesense-config": "^2.0.3",
+    "@magicpages/ghost-typesense-core": "^2.0.3",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.2",
-    "@magicpages/ghost-typesense-core": "^2.0.2",
+    "@magicpages/ghost-typesense-config": "^2.0.3",
+    "@magicpages/ghost-typesense-core": "^2.0.3",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -31,11 +31,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.2",
-        "@magicpages/ghost-typesense-core": "^2.0.2",
+        "@magicpages/ghost-typesense-config": "^2.0.3",
+        "@magicpages/ghost-typesense-core": "^2.0.3",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ora": "^8.0.1"
@@ -144,11 +144,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.2",
-        "@magicpages/ghost-typesense-core": "^2.0.2",
+        "@magicpages/ghost-typesense-config": "^2.0.3",
+        "@magicpages/ghost-typesense-core": "^2.0.3",
         "@netlify/functions": "^2.5.1",
         "zod": "^3.22.4"
       },
@@ -9159,7 +9159,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -9241,10 +9241,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.2",
+        "@magicpages/ghost-typesense-config": "^2.0.3",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "typesense": "^1.7.2",
@@ -9323,7 +9323,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -10058,8 +10058,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.2",
-        "@magicpages/ghost-typesense-core": "^2.0.2",
+        "@magicpages/ghost-typesense-config": "^2.0.3",
+        "@magicpages/ghost-typesense-core": "^2.0.3",
         "@types/node": "^20.11.17",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -10166,7 +10166,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.2",
+        "@magicpages/ghost-typesense-config": "^2.0.3",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "@types/node": "^20.11.17",
@@ -10285,8 +10285,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.2",
-        "@magicpages/ghost-typesense-core": "^2.0.2",
+        "@magicpages/ghost-typesense-config": "^2.0.3",
+        "@magicpages/ghost-typesense-core": "^2.0.3",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^20.11.17",
         "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.2",
+    "@magicpages/ghost-typesense-config": "^2.0.3",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
## Summary

Cuts **2.0.3**. Bumps all published packages to `2.0.3` and documents the release.

2.0.3 ships the analytics transport fix (#37 / #38): the emitter now prefers `fetch(keepalive)` over `navigator.sendBeacon`, so analytics events are no longer silently dropped for readers running content blockers (uBlock Origin et al. block the Beacon API regardless of destination). `sendBeacon` remains only as a fallback for engines without `fetch`.

## Verification

- Built bundle verified: `vector_query` / `semanticSearch` / `uiStyle` present, `keepalive` present, layout chunks built (palette 24KB, discovery 32KB).
- Confirmed in the minified output that `fetch(keepalive)` runs **before** `sendBeacon` in `sendAnalyticsEvent` (fetch is primary, sendBeacon fallback).
- lint, typecheck, 43 tests all pass.

## Files

- `CHANGELOG.md` — `[2.0.3]` entry
- All 6 published `package.json` — `2.0.3`, `@magicpages/*` cross-deps `^2.0.3`
- `package-lock.json` — version strings only

`apps/playground` is private and left at `0.0.0`.

## Test plan

- [x] `npm run lint` / `typecheck` / `test` pass
- [x] Built bundle contains the keepalive fix and all 2.0 features
- [ ] After merge: tag v2.0.3, publish to npm, verify the published tarball