### PR TITLE
fix(core): exclude Ghost internal tags from the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Internal tags were indexed and shown in results.** Ghost internal tags
+  (`visibility: 'internal'`, `#`-prefixed name, `hash-` slug) — which Ghost hides
+  from public output — were written into the `tags` / `tags.name` / `tags.slug`
+  fields, so they were searchable, facetable, and displayed in the result meta
+  line. The indexer now filters them out, matching Ghost's public-output
+  behaviour. Existing collections need a reindex to drop already-indexed
+  internal tags.
+
 ## [2.0.3] - 2026-06-09
 
 ### Fixed

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -310,6 +310,37 @@ describe('GhostTypesenseManager — gated content redaction', () => {
     expect(String(doc.plaintext)).toContain('Readable body');
   });
 
+  it('excludes internal tags from the index (by visibility, # name, or hash- slug)', () => {
+    const manager = new GhostTypesenseManager(baseConfig);
+    const doc = transform(manager, {
+      id: 'pub-2', title: 'Tagged', slug: 'tagged',
+      html: '<p>Body</p>', excerpt: 'x', visibility: 'public',
+      published_at: '2024-02-09T19:00:00.000Z', updated_at: '2024-02-09T19:00:00.000Z',
+      tags: [
+        { name: 'Magic Pages Blog', slug: 'blog', visibility: 'public' },
+        { name: '#updates', slug: 'hash-updates', visibility: 'internal' },
+        // Defensive: an internal tag identifiable only by its name/slug shape.
+        { name: '#podcast', slug: 'hash-podcast' }
+      ]
+    });
+    expect(doc.tags).toEqual(['Magic Pages Blog']);
+    expect(doc['tags.name']).toEqual(['Magic Pages Blog']);
+    expect(doc['tags.slug']).toEqual(['blog']);
+  });
+
+  it('leaves tag fields unset when a post has only internal tags', () => {
+    const manager = new GhostTypesenseManager(baseConfig);
+    const doc = transform(manager, {
+      id: 'pub-3', title: 'Internal only', slug: 'internal-only',
+      html: '<p>Body</p>', excerpt: 'x', visibility: 'public',
+      published_at: '2024-02-09T19:00:00.000Z', updated_at: '2024-02-09T19:00:00.000Z',
+      tags: [{ name: '#updates', slug: 'hash-updates', visibility: 'internal' }]
+    });
+    expect(doc.tags).toBeUndefined();
+    expect(doc['tags.name']).toBeUndefined();
+    expect(doc['tags.slug']).toBeUndefined();
+  });
+
   // Integration through indexPost (the path the webhook uses), driving the
   // mocked Ghost API's gated post.
   describe('indexPost', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,13 @@ import { Client } from 'typesense';
 import type { CollectionFieldSchema } from 'typesense/lib/Typesense/Collection';
 import type { Config } from '@magicpages/ghost-typesense-config';
 
+/**
+ * A single tag as it appears on a Ghost post, derived from the Content API's
+ * own Post type so `name`/`slug`/`visibility` stay accurately typed (all
+ * required) and in sync with the upstream schema.
+ */
+type GhostTag = NonNullable<GhostPost['tags']>[number];
+
 export interface Post {
   id: string;
   title: string;
@@ -92,9 +99,11 @@ export class GhostTypesenseManager {
    * them from public output (the `{{tags}}` theme helper excludes them). The
    * search index is public output, so internal tags must not be indexed,
    * faceted, or shown — any of the three signals is enough to identify one.
+   * The field guards keep a malformed/partial tag from crashing the whole
+   * post's indexing.
    * @private
    */
-  private static isInternalTag(tag: { name?: string; slug?: string; visibility?: string }): boolean {
+  private static isInternalTag(tag: GhostTag): boolean {
     return (
       tag.visibility === 'internal' ||
       (typeof tag.name === 'string' && tag.name.startsWith('#')) ||
@@ -116,14 +125,11 @@ export class GhostTypesenseManager {
 
     const tags = post.tags;
     if (tags && Array.isArray(tags) && tags.length > 0) {
-      const publicTags = tags.filter(
-        (tag: { name?: string; slug?: string; visibility?: string }) =>
-          !GhostTypesenseManager.isInternalTag(tag)
-      );
+      const publicTags = tags.filter((tag) => !GhostTypesenseManager.isInternalTag(tag));
       if (publicTags.length > 0) {
-        transformed['tags.name'] = publicTags.map((tag: { name: string }) => tag.name);
-        transformed['tags.slug'] = publicTags.map((tag: { slug: string }) => tag.slug);
-        transformed.tags = publicTags.map((tag: { name: string }) => tag.name);
+        transformed['tags.name'] = publicTags.map((tag) => tag.name);
+        transformed['tags.slug'] = publicTags.map((tag) => tag.slug);
+        transformed.tags = publicTags.map((tag) => tag.name);
       }
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,9 +87,26 @@ export class GhostTypesenseManager {
   }
 
   /**
+   * Is this an internal (organisational) Ghost tag? Ghost marks these with
+   * `visibility: 'internal'`, a `#`-prefixed name, and a `hash-` slug, and hides
+   * them from public output (the `{{tags}}` theme helper excludes them). The
+   * search index is public output, so internal tags must not be indexed,
+   * faceted, or shown — any of the three signals is enough to identify one.
+   * @private
+   */
+  private static isInternalTag(tag: { name?: string; slug?: string; visibility?: string }): boolean {
+    return (
+      tag.visibility === 'internal' ||
+      (typeof tag.name === 'string' && tag.name.startsWith('#')) ||
+      (typeof tag.slug === 'string' && tag.slug.startsWith('hash-'))
+    );
+  }
+
+  /**
    * Copy tags, authors, and feature image onto a transformed document. Shared
    * by the public and redacted paths — this is all public metadata, safe to
-   * index regardless of visibility.
+   * index regardless of visibility. Internal tags are filtered out so they
+   * never enter the index (mirroring how Ghost hides them from public output).
    * @private
    */
   private applyPostMetadata(post: GhostPost, transformed: Post): void {
@@ -99,9 +116,15 @@ export class GhostTypesenseManager {
 
     const tags = post.tags;
     if (tags && Array.isArray(tags) && tags.length > 0) {
-      transformed['tags.name'] = tags.map((tag: { name: string }) => tag.name);
-      transformed['tags.slug'] = tags.map((tag: { slug: string }) => tag.slug);
-      transformed.tags = tags.map((tag: { name: string }) => tag.name);
+      const publicTags = tags.filter(
+        (tag: { name?: string; slug?: string; visibility?: string }) =>
+          !GhostTypesenseManager.isInternalTag(tag)
+      );
+      if (publicTags.length > 0) {
+        transformed['tags.name'] = publicTags.map((tag: { name: string }) => tag.name);
+        transformed['tags.slug'] = publicTags.map((tag: { slug: string }) => tag.slug);
+        transformed.tags = publicTags.map((tag: { name: string }) => tag.name);
+      }
     }
 
     const authors = post.authors;


### PR DESCRIPTION
## Summary

Ghost **internal tags** (`visibility: 'internal'`, `#`-prefixed name, `hash-` slug) are organisational tags that Ghost hides from public output — its `{{tags}}` theme helper excludes them. The core indexer was mapping all of `post.tags` straight into `tags` / `tags.name` / `tags.slug`, so internal tags became **searchable, facetable, and shown** in the search UI's result meta line (e.g. a result tagged `#updates`).

This filters them out in `applyPostMetadata` via a `isInternalTag()` guard (any of the three signals — visibility / `#` name / `hash-` slug — identifies one). When a post has only internal tags, the tag fields are left unset rather than written as empty arrays. `primary_tag` was already correct (Ghost computes it as the first public tag); only the `tags` arrays leaked.

Found in production: searching on magicpages.co surfaced results whose meta line showed internal tags like `#updates` / `#podcast` alongside genuine tags.

## Test plan

- [x] `npm test` (core) — 15 passing, incl. two new tests: internal tags excluded (by visibility, `#` name, or `hash-` slug), and tag fields left unset when a post has only internal tags
- [x] `typecheck` passes; no new lint warnings (the 9 pre-existing `no-explicit-any` are unrelated)

## Note

Existing collections keep already-indexed internal tags until **reindexed** — same as any indexer-shape change.

The customer-portal has its own indexer with the identical gap (that's what's live on magicpages.co); tracked separately there.

## Summary by Sourcery

Exclude Ghost internal tags from the public search index so only public tags are indexed and exposed in search results.

Bug Fixes:
- Prevent Ghost internal tags from being stored in the tags-related index fields, keeping them from being searchable, facetable, or displayed in result metadata.

Documentation:
- Document the internal-tag indexing fix and reindexing requirement in the Unreleased changelog section.

Tests:
- Add tests ensuring internal tags are filtered out of indexed tag fields and that tag fields remain unset when a post has only internal tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where internal Ghost tags were incorrectly being indexed and appearing in search results. The search index now properly filters out internal tag variants to prevent them from appearing in search functionality. Existing search indexes may require reindexing to remove previously indexed internal tags from your search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->