### PR TITLE
chore: release 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.4] - 2026-06-13
 
 ### Fixed
 - **Internal tags were indexed and shown in results.** Ghost internal tags
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line. The indexer now filters them out, matching Ghost's public-output
   behaviour. Existing collections need a reindex to drop already-indexed
   internal tags.
+
+### Changed
+- Added a `prepublishOnly` build step to the search-ui package so the published
+  `dist/` can never go stale relative to source (the failure mode behind the
+  bad 2.0.0 / 2.0.1 publishes).
 
 ## [2.0.3] - 2026-06-09
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "CLI tool for managing Ghost content in Typesense",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,8 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.3",
-    "@magicpages/ghost-typesense-core": "^2.0.3",
+    "@magicpages/ghost-typesense-config": "^2.0.4",
+    "@magicpages/ghost-typesense-core": "^2.0.4",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.3",
-    "@magicpages/ghost-typesense-core": "^2.0.3",
+    "@magicpages/ghost-typesense-config": "^2.0.4",
+    "@magicpages/ghost-typesense-core": "^2.0.4",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -31,11 +31,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.3",
-        "@magicpages/ghost-typesense-core": "^2.0.3",
+        "@magicpages/ghost-typesense-config": "^2.0.4",
+        "@magicpages/ghost-typesense-core": "^2.0.4",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ora": "^8.0.1"
@@ -144,11 +144,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.3",
-        "@magicpages/ghost-typesense-core": "^2.0.3",
+        "@magicpages/ghost-typesense-config": "^2.0.4",
+        "@magicpages/ghost-typesense-core": "^2.0.4",
         "@netlify/functions": "^2.5.1",
         "zod": "^3.22.4"
       },
@@ -9159,7 +9159,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -9241,10 +9241,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.3",
+        "@magicpages/ghost-typesense-config": "^2.0.4",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "typesense": "^1.7.2",
@@ -9323,7 +9323,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -10058,8 +10058,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.3",
-        "@magicpages/ghost-typesense-core": "^2.0.3",
+        "@magicpages/ghost-typesense-config": "^2.0.4",
+        "@magicpages/ghost-typesense-core": "^2.0.4",
         "@types/node": "^20.11.17",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -10166,7 +10166,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.3",
+        "@magicpages/ghost-typesense-config": "^2.0.4",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "@types/node": "^20.11.17",
@@ -10285,8 +10285,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.3",
-        "@magicpages/ghost-typesense-core": "^2.0.3",
+        "@magicpages/ghost-typesense-config": "^2.0.4",
+        "@magicpages/ghost-typesense-core": "^2.0.4",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^20.11.17",
         "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.3",
+    "@magicpages/ghost-typesense-config": "^2.0.4",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "lint": "eslint src/**/*.js",
     "format": "prettier --write src/**/*.{js,css}",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "ghost",


### PR DESCRIPTION
## Summary

Cuts **2.0.4**. Bumps all published packages to `2.0.4` and documents the release.

### What's in it
- **Internal-tag indexing fix (#40)** — Ghost internal tags (`visibility: 'internal'` / `#` name / `hash-` slug) are no longer indexed, faceted, or shown in results, matching Ghost's public-output behaviour.
- **`prepublishOnly` guard** added to the search-ui package — `npm publish` now rebuilds `dist/` automatically, so the published bundle can never go stale relative to source (the failure behind the bad 2.0.0 / 2.0.1 publishes).

### Verification
- Core built output (`packages/core/dist/index.js`) contains the `isInternalTag` filter.
- search-ui bundle verified: `vector_query` / `semanticSearch` / `uiStyle` / `keepalive` present, `fetch` runs before `sendBeacon`, both layout chunks built.
- `npm publish --dry-run` confirmed the `prepublishOnly` step fires (rebuilds all three bundles) and packs the correct tarball (search.min.js 187.3kB + palette + discovery, 5 files).
- lint, typecheck, all tests pass.

### Note
Existing collections need a **reindex** to drop already-indexed internal tags. The customer-portal has its own indexer with the same gap (tracked in customer-portal #2118); this release covers the OSS package only.

## Files
- `CHANGELOG.md` — `[2.0.4]` entry
- All 6 published `package.json` — `2.0.4`, `@magicpages/*` cross-deps `^2.0.4`; search-ui also gains `prepublishOnly`
- `package-lock.json` — version strings only

`apps/playground` is private and left at `0.0.0`.

## Test plan
- [x] lint / typecheck / test pass
- [x] core build contains the internal-tag filter; search-ui bundle verified
- [x] `prepublishOnly` fires on publish dry-run
- [ ] After merge: tag v2.0.4, publish to npm, verify the published tarball

## Summary by Sourcery

Cut release 2.0.4 across the monorepo and document the changes.

Enhancements:
- Add a prepublishOnly build step to the search-ui package to ensure the published bundle is rebuilt before publishing.

Build:
- Bump all published packages and cross-dependencies from 2.0.3 to 2.0.4.

Documentation:
- Update CHANGELOG with the 2.0.4 release entry, including internal tag indexing fix and publishing safeguards.