### PR TITLE
fix: keep bundled CSS const inside the IIFE to stop global collision

### DIFF
--- a/packages/search-ui/rollup.config.js
+++ b/packages/search-ui/rollup.config.js
@@ -54,7 +54,13 @@ export default [
       name: 'MagicPagesSearch',
       inlineDynamicImports: true,
       generatedCode,
-      banner: `const BUNDLED_CSS = ${JSON.stringify(coreCss)};`
+      // `intro` (not `banner`) so the CSS constant is emitted INSIDE the IIFE
+      // wrapper and stays function-scoped. With `banner` it landed at global
+      // scope, where terser's toplevel mangle renamed it to `const t` — a
+      // global lexical that throws "Identifier 't' has already been declared"
+      // whenever another page script defines a global `t`, aborting the whole
+      // bundle before it can run.
+      intro: `const BUNDLED_CSS = ${JSON.stringify(coreCss)};`
     },
     plugins: plugins()
   },
@@ -70,7 +76,8 @@ export default [
       name: 'MagicPagesSearchPalette',
       inlineDynamicImports: true,
       generatedCode,
-      banner: `const LAYOUT_CSS = ${JSON.stringify(paletteCss)};`
+      // See the core bundle above: `intro` keeps the CSS constant inside the IIFE.
+      intro: `const LAYOUT_CSS = ${JSON.stringify(paletteCss)};`
     },
     plugins: plugins()
   },
@@ -84,7 +91,8 @@ export default [
       name: 'MagicPagesSearchDiscovery',
       inlineDynamicImports: true,
       generatedCode,
-      banner: `const LAYOUT_CSS = ${JSON.stringify(discoveryCss)};`
+      // See the core bundle above: `intro` keeps the CSS constant inside the IIFE.
+      intro: `const LAYOUT_CSS = ${JSON.stringify(discoveryCss)};`
     },
     plugins: plugins()
   }

--- a/packages/search-ui/rollup.config.js
+++ b/packages/search-ui/rollup.config.js
@@ -42,6 +42,12 @@ const plugins = () => [
 const treeshake = { preset: 'recommended', moduleSideEffects: true, propertyReadSideEffects: true };
 const generatedCode = { preset: 'es2015', constBindings: true };
 
+// Every bundle injects its inlined CSS via `intro` (NOT `banner`). `intro` is
+// emitted INSIDE the IIFE wrapper, so the CSS constant stays function-scoped.
+// With `banner` it landed at global scope, where terser's toplevel mangle
+// renamed it to `const t` — a global lexical that throws "Identifier 't' has
+// already been declared" whenever another page script defines a global `t`,
+// aborting the whole bundle before it can run.
 export default [
   // Core bundle: widget engine + the default inline modal layout. This is the
   // single classic <script> every install loads today — unchanged contract.
@@ -54,12 +60,6 @@ export default [
       name: 'MagicPagesSearch',
       inlineDynamicImports: true,
       generatedCode,
-      // `intro` (not `banner`) so the CSS constant is emitted INSIDE the IIFE
-      // wrapper and stays function-scoped. With `banner` it landed at global
-      // scope, where terser's toplevel mangle renamed it to `const t` — a
-      // global lexical that throws "Identifier 't' has already been declared"
-      // whenever another page script defines a global `t`, aborting the whole
-      // bundle before it can run.
       intro: `const BUNDLED_CSS = ${JSON.stringify(coreCss)};`
     },
     plugins: plugins()
@@ -76,7 +76,6 @@ export default [
       name: 'MagicPagesSearchPalette',
       inlineDynamicImports: true,
       generatedCode,
-      // See the core bundle above: `intro` keeps the CSS constant inside the IIFE.
       intro: `const LAYOUT_CSS = ${JSON.stringify(paletteCss)};`
     },
     plugins: plugins()
@@ -91,7 +90,6 @@ export default [
       name: 'MagicPagesSearchDiscovery',
       inlineDynamicImports: true,
       generatedCode,
-      // See the core bundle above: `intro` keeps the CSS constant inside the IIFE.
       intro: `const LAYOUT_CSS = ${JSON.stringify(discoveryCss)};`
     },
     plugins: plugins()


### PR DESCRIPTION
## Problem

On sites where another script defines a global `t` (common in minified Ghost/theme bundles), the search bundle dies on its first line:

```
Uncaught SyntaxError: redeclaration of non-configurable global property t
    search.min.js:1
```

A top-level `SyntaxError` aborts the **entire** script before its IIFE runs, so `window.MagicPagesSearch` is never defined and search silently fails to load. Observed live on https://www.buurtaal.de/ (there `window.MagicPagesSearch` was `undefined`).

## Root cause

`packages/search-ui/rollup.config.js` injected the inlined CSS via Rollup's **`banner`** option:

```js
banner: `const BUNDLED_CSS = ${JSON.stringify(coreCss)};`
```

`banner` emits code **outside** the IIFE wrapper, so `BUNDLED_CSS` (and the layouts' `LAYOUT_CSS`) lived at true global scope. Terser's `toplevel` mangle then renamed it to a single-letter global lexical **`const t`** — which collides with any other page-global `t`.

## Fix

Switch `banner` → **`intro`** for all three bundles (core + palette + discovery). `intro` is emitted **inside** the IIFE, so the CSS constant is function-scoped and can no longer leak to the global object or collide.

The rebuilt `dist/search.min.js` now begins with `!function(){const t="…css…"…` — the const is private to the IIFE.

## Verification

- Served the rebuilt bundle on a page that pre-defines a non-configurable global `t` (reproducing buurtaal): **no `SyntaxError`**, the page's own `t` is preserved, and `window.MagicPagesSearch` initialises (`function`).
- `npm test` — all 43 unit tests pass.

## Follow-up

`dist/` is gitignored, so this needs a patch release (2.0.5) + republish for deployed sites to pick it up. Any site whose page defines a global `t` is currently affected.

## Summary by Sourcery

Bug Fixes:
- Prevent search bundle from throwing a global SyntaxError when other scripts define a conflicting global identifier (such as a non-configurable global `t`) by emitting CSS constants inside the IIFE via Rollup's intro option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS constant injection in bundle output to prevent naming conflicts that could disrupt execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->