### PR TITLE
chore: release 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2026-06-22
+
+### Fixed
+- **Search failed to load on pages that define a global `t`.** The search-ui
+  bundles injected their inlined CSS via Rollup's `banner` option, which emits
+  code *outside* the IIFE wrapper — so `BUNDLED_CSS` (and the layouts'
+  `LAYOUT_CSS`) sat at global scope, where terser's `toplevel` mangle renamed it
+  to a single-letter global lexical `const t`. On any page where another script
+  already defines a global `t` (common in minified Ghost/theme bundles), the
+  redeclaration threw `Identifier 't' has already been declared` on the first
+  line of `search.min.js`. A top-level `SyntaxError` aborts the *entire* script
+  before its IIFE runs, so `window.MagicPagesSearch` was never defined and search
+  silently failed to load. The CSS is now injected via `intro`, which is emitted
+  *inside* the IIFE, keeping the constant function-scoped so it can no longer
+  leak to the global object or collide. Affects the core, palette, and discovery
+  bundles. No source changes — build/release fix only; update and redeploy the
+  rebuilt bundle.
+
 ## [2.0.4] - 2026-06-13
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "CLI tool for managing Ghost content in Typesense",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,8 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.4",
-    "@magicpages/ghost-typesense-core": "^2.0.4",
+    "@magicpages/ghost-typesense-config": "^2.0.5",
+    "@magicpages/ghost-typesense-core": "^2.0.5",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.4",
-    "@magicpages/ghost-typesense-core": "^2.0.4",
+    "@magicpages/ghost-typesense-config": "^2.0.5",
+    "@magicpages/ghost-typesense-core": "^2.0.5",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -31,11 +31,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.4",
-        "@magicpages/ghost-typesense-core": "^2.0.4",
+        "@magicpages/ghost-typesense-config": "^2.0.5",
+        "@magicpages/ghost-typesense-core": "^2.0.5",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ora": "^8.0.1"
@@ -144,11 +144,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.4",
-        "@magicpages/ghost-typesense-core": "^2.0.4",
+        "@magicpages/ghost-typesense-config": "^2.0.5",
+        "@magicpages/ghost-typesense-core": "^2.0.5",
         "@netlify/functions": "^2.5.1",
         "zod": "^3.22.4"
       },
@@ -9159,7 +9159,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -9241,10 +9241,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.4",
+        "@magicpages/ghost-typesense-config": "^2.0.5",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "typesense": "^1.7.2",
@@ -9323,7 +9323,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -10058,8 +10058,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.4",
-        "@magicpages/ghost-typesense-core": "^2.0.4",
+        "@magicpages/ghost-typesense-config": "^2.0.5",
+        "@magicpages/ghost-typesense-core": "^2.0.5",
         "@types/node": "^20.11.17",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -10166,7 +10166,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.4",
+        "@magicpages/ghost-typesense-config": "^2.0.5",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "@types/node": "^20.11.17",
@@ -10285,8 +10285,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.4",
-        "@magicpages/ghost-typesense-core": "^2.0.4",
+        "@magicpages/ghost-typesense-config": "^2.0.5",
+        "@magicpages/ghost-typesense-core": "^2.0.5",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^20.11.17",
         "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.4",
+    "@magicpages/ghost-typesense-config": "^2.0.5",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
Bumps all published packages to **2.0.5** and documents the release.

## What's in 2.0.5

Ships the search-bundle global-collision fix (#44):

- The inlined CSS constant is now emitted **inside** the IIFE via Rollup's `intro` instead of `banner`, so terser can no longer leak it as a global `const t`.
- On pages where another script defines a global `t` (common in minified Ghost/theme bundles), the old bundle threw a top-level `SyntaxError` on line 1 of `search.min.js`, which aborted the whole script — `window.MagicPagesSearch` never initialised and search silently failed to load (observed on buurtaal.de).
- Affects the core, palette, and discovery bundles.

This is a build/release fix only — no source changes versus 2.0.4.

## Changes

- All package versions 2.0.4 → 2.0.5 (+ internal `@magicpages/*` dep refs + `package-lock.json`)
- CHANGELOG entry for 2.0.5

## Verification

- `npm test` — all 11 turbo tasks pass (43 unit tests in search-ui)
- Rebuilt bundles all start with `!function(){` (CSS const inside the IIFE)

## Summary by Sourcery

Release version 2.0.5 across all packages and document the search bundle global-collision fix.

Bug Fixes:
- Document the fix for search bundles failing to load on pages defining a global `t`, clarifying that the CSS-injection change removes the global collision and restores search initialisation.

Build:
- Bump all package versions and internal @magicpages/* dependency ranges from 2.0.4 to 2.0.5, including the root package and lockfile.

Documentation:
- Add a CHANGELOG entry describing the 2.0.5 release and its search bundle global-collision fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search failing to load on certain web pages

* **Chores**
  * Released version 2.0.5 with dependency updates across core packages and applications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->