### PR TITLE
fix(search-ui): omit discovery preview hero when post has no feature image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2026-06-24
+
+### Changed
+- **Discovery layout no longer shows a placeholder for posts without a feature
+  image.** The discovery preview pane rendered a grey placeholder hero (a framed
+  image icon) whenever the selected post had no `feature_image`. On text-led
+  publications that meant a placeholder on effectively every result. The preview
+  now omits the hero entirely when there is no image, so an image-less post reads
+  as a clean text preview; the hero image still renders when one is present. The
+  modal `grid` template's own placeholder is unchanged. Search-ui bundle change
+  only — update and redeploy the rebuilt `discovery.min.js`.
+
 ## [2.0.5] - 2026-06-22
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "CLI tool for managing Ghost content in Typesense",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,8 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.5",
-    "@magicpages/ghost-typesense-core": "^2.0.5",
+    "@magicpages/ghost-typesense-config": "^2.0.6",
+    "@magicpages/ghost-typesense-core": "^2.0.6",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.5",
-    "@magicpages/ghost-typesense-core": "^2.0.5",
+    "@magicpages/ghost-typesense-config": "^2.0.6",
+    "@magicpages/ghost-typesense-core": "^2.0.6",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.5",
+    "@magicpages/ghost-typesense-config": "^2.0.6",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import createDiscoveryLayout from '../layouts/discovery.js';
+
+// Minimal layout context. The discovery factory only touches the core through
+// this object; for rendering we need the prefix, an HTML-attribute escaper, and
+// the translation helper (echoing the key is enough for assertions).
+function makeCtx() {
+  return {
+    prefix: 'mp-search',
+    escapeHtmlAttr: (v) =>
+      String(v ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;'),
+    t: (k) => k
+  };
+}
+
+// Mount the layout into a real shadow root (so getElementById works the same as
+// in the live widget) and return the layout plus its cached preview element.
+function mountDiscovery() {
+  const layout = createDiscoveryLayout(makeCtx());
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = layout.buildMarkup();
+  layout.cacheElements(shadow);
+  return { layout, shadow };
+}
+
+function modelWith(featureImage) {
+  return [
+    {
+      id: 'p1',
+      position: 0,
+      url: '/post/',
+      title: 'A post',
+      titleHtml: 'A post',
+      ariaTitle: 'A post',
+      excerptHtml: 'Body teaser',
+      isGated: false,
+      visibility: 'public',
+      featureImage,
+      tags: ['Trade'],
+      authors: ['Simon'],
+      publishedAt: 1700000000000
+    }
+  ];
+}
+
+describe('discovery preview hero', () => {
+  it('omits the hero entirely when the selected result has no feature image', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith(null), { found: 1 });
+
+    const preview = shadow.getElementById('mp-search-discovery-preview');
+    // No image and — the point of this change — no placeholder box either.
+    expect(preview.querySelector('.mp-search-discovery-hero')).toBeNull();
+    expect(preview.querySelector('.mp-search-discovery-hero-empty')).toBeNull();
+    // The rest of the preview still renders.
+    expect(preview.querySelector('.mp-search-discovery-preview-title').textContent).toContain('A post');
+  });
+
+  it('renders the hero image when the selected result has a feature image', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith('https://cdn.example.com/p.jpg'), { found: 1 });
+
+    const preview = shadow.getElementById('mp-search-discovery-preview');
+    const img = preview.querySelector('img.mp-search-discovery-hero');
+    expect(img).not.toBeNull();
+    expect(img.getAttribute('src')).toBe('https://cdn.example.com/p.jpg');
+  });
+});

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import createDiscoveryLayout from '../layouts/discovery.js';
+
+// Hosts mounted during a test, torn down afterwards so DOM fixtures never leak
+// across tests sharing the jsdom environment.
+let mountedHosts = [];
+
+afterEach(() => {
+  for (const host of mountedHosts) host.remove();
+  mountedHosts = [];
+});
 
 // Minimal layout context. The discovery factory only touches the core through
 // this object; for rendering we need the prefix, an HTML-attribute escaper, and
@@ -24,6 +33,7 @@ function mountDiscovery() {
   const layout = createDiscoveryLayout(makeCtx());
   const host = document.createElement('div');
   document.body.appendChild(host);
+  mountedHosts.push(host);
   const shadow = host.attachShadow({ mode: 'open' });
   shadow.innerHTML = layout.buildMarkup();
   layout.cacheElements(shadow);

--- a/packages/search-ui/src/layouts/discovery.css
+++ b/packages/search-ui/src/layouts/discovery.css
@@ -424,21 +424,6 @@
   display: block;
 }
 
-.mp-search-discovery-hero-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, var(--accent-color) 10%, var(--color-surface));
-  border: 1px solid var(--color-border);
-  color: color-mix(in srgb, var(--accent-color) 70%, var(--color-text));
-}
-
-.mp-search-discovery-hero-empty svg {
-  width: calc(2.5 * var(--mp-rem));
-  height: calc(2.5 * var(--mp-rem));
-  opacity: 0.7;
-}
-
 .mp-search-discovery-preview-title {
   color: var(--color-text);
   font-size: calc(1.375 * var(--mp-rem));

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -63,16 +63,6 @@ export default function createDiscoveryLayout(ctx) {
       + `<span aria-hidden="true">🔒</span> ${esc(ctx.t('membersLabel'))}</span>`;
   }
 
-  // A hero placeholder for posts without a feature image.
-  function heroPlaceholder() {
-    return `<div class="${P}-discovery-hero ${P}-discovery-hero-empty" aria-hidden="true">`
-      + `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" `
-      + `stroke-linecap="round" stroke-linejoin="round">`
-      + `<rect x="3" y="3" width="18" height="18" rx="2" />`
-      + `<circle cx="8.5" cy="8.5" r="1.5" />`
-      + `<path d="M21 15l-5-5L5 21" /></svg></div>`;
-  }
-
   // ---- Selection ----------------------------------------------------------
 
   function applySelectionClasses() {
@@ -134,13 +124,13 @@ export default function createDiscoveryLayout(ctx) {
 
     const parts = [];
 
-    // Hero image (feature_image is often null) — placeholder otherwise.
+    // Hero image — feature_image is often null (e.g. text-only posts). When it
+    // is absent the preview omits the hero entirely rather than showing a
+    // placeholder, so an image-less post reads as a clean text preview.
     if (m.featureImage) {
       parts.push(
         `<img class="${P}-discovery-hero" src="${esc(m.featureImage)}" alt="" loading="lazy" />`
       );
-    } else {
-      parts.push(heroPlaceholder());
     }
 
     // Title — trusted highlight markup.


### PR DESCRIPTION
## What & why

In the **discovery** layout, the right-hand preview pane rendered a grey placeholder hero (a framed image icon) for any post without a `feature_image`. On text-led publications that meant a placeholder on effectively *every* result.

This drops the placeholder entirely: when a post has no image, the preview omits the hero and reads as a clean text preview. The hero `<img>` still renders when an image is present.

## Changes

- `layouts/discovery.js` — `renderPreview` only emits the `<img>` hero when `featureImage` is set; removed the now-dead `heroPlaceholder()` helper.
- `layouts/discovery.css` — removed the orphaned `.mp-search-discovery-hero-empty` rules.
- `__tests__/discovery.test.js` *(new)* — first test coverage for the discovery layout: no image → no hero/placeholder element; image → `<img>` hero with correct `src`.
- Version bump to **2.0.6** across all packages + CHANGELOG entry.

## Scope

Discovery layout only. The modal **`grid`** template's own placeholder (`.mp-search-card-image-empty`) is intentionally left unchanged.

## Testing

- `npm test` (monorepo): 11/11 turbo tasks pass; search-ui 45 tests incl. the 2 new ones.
- `npm run lint`: clean. `npm run build`: rebuilds `discovery.min.js` (confirmed no `hero-empty` markup remains).

## Shipping note

Bundles ship via `npm publish`, not committed `dist/`. After merge: publish 2.0.6, then customer-portal needs to re-install the latest bundle into sites' `content/files/search/` for the change to reach readers.

## Summary by Sourcery

Remove placeholder hero images from the discovery search preview for posts without feature images and bump the package version to 2.0.6.

Bug Fixes:
- Stop rendering a placeholder hero in the discovery layout preview when posts have no feature image, so text-only results display as clean text previews.

Enhancements:
- Clean up discovery layout styles by removing unused hero placeholder CSS and ensuring the preview only renders a hero when an image exists.

Build:
- Bump all packages to version 2.0.6 and update internal dependency ranges accordingly.

Documentation:
- Add a 2.0.6 changelog entry describing the discovery layout change and deployment note for the updated search-ui bundle.

Tests:
- Add discovery layout tests verifying that the preview omits the hero when no feature image is present and renders it with the correct source when provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discovery previews now hide the hero area entirely when an item has no image, creating a cleaner text-only layout.
  * The existing modal grid view keeps its current placeholder behavior.

* **Chores**
  * Updated release versions across the package set for v2.0.6.
  * Refreshed the search UI bundle and changelog for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
