### PR TITLE
ci: publish to npm on GitHub Release via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# Publishes the packages to npm when a GitHub Release is published.
+#
+# Flow (versioning stays manual — see scripts/bump-versions.js):
+#   1. Bump every package version (node scripts/bump-versions.js) and write the
+#      matching CHANGELOG entry, on a PR. Merge to main.
+#   2. Draft a GitHub Release whose tag is `v<version>` matching the root
+#      package.json version (e.g. v2.0.6). Publishing the release triggers this
+#      workflow, which builds and publishes every public package to npm.
+#      Publishing to npm is what makes the unpkg / jsDelivr CDN URLs live.
+#
+# Auth: npm Trusted Publishing (OIDC). No NPM_TOKEN secret is stored — the
+# `id-token: write` permission lets the runner mint a short-lived token, and
+# NPM_CONFIG_PROVENANCE stamps each publish with a verifiable link back to this
+# workflow + commit. The trusted publisher must be configured once on npmjs.com
+# for EACH package (package → Settings → Trusted Publisher → GitHub Actions,
+# repository `magicpages/ghost-typesense`, workflow `release.yml`):
+#   - @magicpages/ghost-typesense-config
+#   - @magicpages/ghost-typesense-core
+#   - @magicpages/ghost-typesense-search-ui
+#   - @magicpages/ghost-typesense-cli
+#   - @magicpages/ghost-typesense-webhook
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: build · publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # OIDC for npm Trusted Publishing + provenance
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install
+        run: npm ci
+
+      # Trusted Publishing + provenance need a recent npm; the Node 20 pinned in
+      # .nvmrc ships an older one, so upgrade before publishing.
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Build
+        run: npm run build
+
+      # Guard: the release tag must match the version in package.json, so we
+      # never publish a version the tag/changelog doesn't describe.
+      - name: Verify tag matches version
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="v$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Release tag '$tag' does not match package version '$version'"
+            exit 1
+          fi
+          echo "Releasing $version"
+
+      # Publish each public package in dependency order (config → core →
+      # search-ui → cli → webhook-handler). A version already on npm is skipped,
+      # so re-running a failed release is safe and partial publishes recover.
+      - name: Publish to npm
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
+        run: |
+          set -euo pipefail
+          for dir in packages/config packages/core packages/search-ui apps/cli apps/webhook-handler; do
+            name=$(node -p "require('./$dir/package.json').name")
+            version=$(node -p "require('./$dir/package.json').version")
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "✓ $name@$version already on npm — skipping"
+            else
+              echo "→ publishing $name@$version"
+              ( cd "$dir" && npm publish )
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,12 @@ jobs:
       - name: Install
         run: npm ci
 
-      # Trusted Publishing + provenance need a recent npm; the Node 20 pinned in
-      # .nvmrc ships an older one, so upgrade before publishing.
+      # Trusted Publishing + provenance need npm >= 11.5.1; the Node 20 pinned in
+      # .nvmrc ships npm 10, so upgrade before publishing. Pinned to the npm 11
+      # major (not @latest) for reproducible releases — npm 10 has no trusted
+      # publishing, so this floor must never drop below 11.
       - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Build
         run: npm run build

--- a/scripts/bump-versions.js
+++ b/scripts/bump-versions.js
@@ -92,10 +92,9 @@ for (const pkg of packages) {
   console.log(`Updated ${pkg}`);
 }
 
-console.log('\nDone! Now run:');
-console.log('npm run build');
-console.log('cd packages/config && npm publish');
-console.log('cd ../core && npm publish');
-console.log('cd ../search-ui && npm publish');
-console.log('cd ../../apps/cli && npm publish');
-console.log('cd ../webhook-handler && npm publish');
+console.log('\nDone! Next:');
+console.log(`  1. Add the ${newVersion} entry to CHANGELOG.md.`);
+console.log('  2. Commit the version bump + changelog and open a PR; merge to main.');
+console.log(`  3. Draft a GitHub Release with tag v${newVersion} (matching the version).`);
+console.log('     Publishing the release runs .github/workflows/release.yml, which');
+console.log('     builds and publishes every package to npm via trusted publishing.');


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — when a **GitHub Release is published**, it builds and publishes every public package to npm:

`@magicpages/ghost-typesense-config` → `-core` → `-search-ui` → `-cli` → `-webhook` (dependency order).

Mirrors the **kalotyp** publishing mechanism: **npm Trusted Publishing (OIDC)** with provenance — **no `NPM_TOKEN` secret**. Versioning stays manual (`scripts/bump-versions.js` + hand-written CHANGELOG); this workflow only does the npm push.

## Why on release (not changesets)

kalotyp uses changesets to *generate* versions/changelog. Here we keep the existing manual flow — you confirmed the hand-written CHANGELOG is what we want — and just automate the npm push. Trigger is `release: published`, matching "npm push whenever we have a release."

## Safety

- **Tag guard**: fails unless the release tag is `v<root package.json version>` (e.g. `v2.0.6`), so we can't publish a version the tag/changelog doesn't describe.
- **Idempotent**: each package whose version is already on npm is skipped, so a re-run after a partial/failed publish recovers cleanly.
- `npm install -g npm@latest` step ensures OIDC/provenance support on the Node 20 runner.

## ⚠️ One-time setup required before the first release

Trusted Publishing must be configured **once per package** on npmjs.com:
Package → **Settings → Trusted Publisher → GitHub Actions**, repo `magicpages/ghost-typesense`, workflow `release.yml`. Do this for all five packages above. Until then the publish step will fail (no token fallback by design).

## Rollout for 2.0.6

1. Merge this PR.
2. Configure the five trusted publishers on npmjs.com.
3. Cut a GitHub Release tagged `v2.0.6` → this workflow publishes 2.0.6 (the merged `fix/discovery-omit-empty-hero` change).

Also updates `bump-versions.js`'s closing instructions to describe this flow instead of manual `npm publish`.

## Summary by Sourcery

Automate npm publishing of all public packages when a GitHub Release is published using npm Trusted Publishing, and align the version bump script’s instructions with the new release workflow.

Enhancements:
- Update bump-versions.js to guide maintainers through updating the changelog, merging to main, and cutting a matching GitHub Release instead of running manual npm publish commands.

CI:
- Add a GitHub Actions release workflow that builds the project and publishes all public packages to npm on GitHub Release publication using OIDC-based Trusted Publishing, with tag/version guards and idempotent publishing.