### PR TITLE
fix(cli): add repository field so provenance publish succeeds

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,6 +2,11 @@
   "name": "@magicpages/ghost-typesense-cli",
   "version": "2.0.6",
   "description": "CLI tool for managing Ghost content in Typesense",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/magicpages/ghost-typesense.git",
+    "directory": "apps/cli"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "bin": {


### PR DESCRIPTION
The v2.0.6 release workflow published `config`, `core`, and `search-ui` with provenance, then **failed on `cli`**:

```
npm error code E422
422 Unprocessable Entity ... Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match
"https://github.com/magicpages/ghost-typesense" from provenance
```

`apps/cli/package.json` had **no `repository` field**, which provenance verification requires. (`webhook-handler` already has one — it just never got its turn after cli failed.)

This adds the `repository` field matching the other packages. After merge, re-cutting the v2.0.6 release will skip the three already-published packages and publish `cli@2.0.6` + `webhook@2.0.6` with valid provenance.