### PR TITLE
ci: notify customer-portal when search-ui is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,26 @@ jobs:
               ( cd "$dir" && npm publish )
             fi
           done
+
+      # Tell the customer portal a new search-ui is live so it opens a bump PR
+      # within seconds (see customer-portal .github/workflows/
+      # ghost-typesense-search-ui-bump.yml). Best-effort: a missing token or API
+      # hiccup must not fail an otherwise-successful release — the portal's
+      # weekly Dependabot run is the safety net. Needs a fine-grained PAT with
+      # "Contents: write" on magicpages/customer-portal stored as the
+      # CUSTOMER_PORTAL_DISPATCH_TOKEN secret (GITHUB_TOKEN can't reach another
+      # repo).
+      - name: Notify customer-portal of the new search-ui release
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.CUSTOMER_PORTAL_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::CUSTOMER_PORTAL_DISPATCH_TOKEN not set — skipping portal bump dispatch"
+            exit 0
+          fi
+          payload=$(node -p "JSON.stringify({ event_type: 'ghost-typesense-search-ui-released', client_payload: { version: require('./packages/search-ui/package.json').version } })")
+          echo "Dispatching to customer-portal: $payload"
+          printf '%s' "$payload" | gh api --method POST repos/magicpages/customer-portal/dispatches --input -


### PR DESCRIPTION
## Summary

After the npm publish step in `release.yml`, fire a `repository_dispatch` to `magicpages/customer-portal` carrying the new `@magicpages/ghost-typesense-search-ui` version. The portal listens for it ([customer-portal#2247](https://github.com/magicpages/customer-portal/pull/2247)) and opens a PR bumping its pin within seconds of the release — instead of waiting up to a week for its Dependabot run.

## Behaviour

- **Best-effort / non-fatal:** `continue-on-error: true` plus an explicit skip-with-warning when the token is unset. A dispatch failure never fails an otherwise-successful release (the publish already happened).
- Sends the **search-ui package's own version** (`packages/search-ui/package.json`), built as JSON via `node -p` and piped to `gh api --input -` (no shell interpolation of the value).

## Required setup

Add a repo secret **`CUSTOMER_PORTAL_DISPATCH_TOKEN`** — a fine-grained PAT with **Contents: write** on `magicpages/customer-portal` (the `GITHUB_TOKEN` here is scoped to this repo only and can't dispatch cross-repo). Until it's set, the step logs a warning and skips; releases still publish normally and the portal's weekly Dependabot net covers the gap.

## Test plan

- [x] `release.yml` parses; dispatch is the final publish-job step
- [ ] Add the secret, publish a release, confirm a bump PR opens on customer-portal

## Summary by Sourcery

CI:
- Extend the release workflow to send a repository_dispatch event with the new search-ui package version to magicpages/customer-portal, guarded by an optional PAT-backed token and non-fatal on failure.