### PR TITLE
feat(core): exclude posts tagged #no-search-index from the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,21 @@ With it enabled:
 
 For real-time updates, set `INDEX_GATED_CONTENT=true` on the webhook handler to mirror this behaviour.
 
+## Excluding individual posts
+
+Some posts shouldn't be searchable at all — landing pages, legal/policy pages, internal notes. Tag them and they're kept out of the index entirely (and, via the webhook handler, an edit that *adds* the tag de-indexes the post).
+
+By default the indexer excludes any post carrying the **`#no-search-index`** tag (a Ghost internal tag — `#`-prefixed tags are hidden from your site's public output anyway). Override the list — or disable it — with `excludeTags` on the collection config:
+
+```jsonc
+"collection": {
+    "name": "posts",
+    "excludeTags": ["#no-search-index", "Internal"]  // [] disables exclusion
+}
+```
+
+Each value is matched case-insensitively against a post's Ghost tag **names and slugs**, so the internal-tag form (`#no-search-index` / `hash-no-search-index`) is caught however the tag was created.
+
 ## Packages
 
 | Package | Description |

--- a/packages/config/src/__tests__/index.test.ts
+++ b/packages/config/src/__tests__/index.test.ts
@@ -235,3 +235,33 @@ describe('Gated content config', () => {
     expect(field?.optional).toBe(true);
   });
 });
+
+describe('excludeTags config', () => {
+  const base = {
+    ghost: { url: 'https://example.com', key: 'valid-key', version: 'v5.0' },
+    typesense: { nodes: [{ host: 'localhost', port: 8108, protocol: 'http' }], apiKey: 'valid-key' }
+  };
+
+  it('leaves excludeTags undefined when omitted (the indexer applies the default)', () => {
+    const config = validateConfig({ ...base, collection: { name: 'posts' } });
+    expect(config.collection.excludeTags).toBeUndefined();
+  });
+
+  it('accepts a custom exclude list', () => {
+    const config = validateConfig({
+      ...base,
+      collection: { name: 'posts', excludeTags: ['#no-search-index', 'Internal'] }
+    });
+    expect(config.collection.excludeTags).toEqual(['#no-search-index', 'Internal']);
+  });
+
+  it('accepts an empty array (disables exclusion)', () => {
+    const config = validateConfig({ ...base, collection: { name: 'posts', excludeTags: [] } });
+    expect(config.collection.excludeTags).toEqual([]);
+  });
+
+  it('createDefaultConfig surfaces the #no-search-index convention', () => {
+    const config = createDefaultConfig('https://example.com', 'k', 'host', 'tk');
+    expect(config.collection.excludeTags).toEqual(['#no-search-index']);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -156,7 +156,15 @@ export const CollectionConfigSchema = z.object({
   // Omitted/undefined is treated as false, so only public published content is
   // indexed by default. Left optional (no schema default) so existing config
   // objects remain valid without this key.
-  indexGatedContent: z.boolean().optional()
+  indexGatedContent: z.boolean().optional(),
+  // Posts carrying any of these tags are excluded from the index entirely — a
+  // content-policy escape hatch for landing/legal/internal pages a publisher
+  // doesn't want searchable. Each value is matched against a post's Ghost tag
+  // names and slugs (case-insensitive), so the canonical `#no-search-index`
+  // internal tag works out of the box. Left optional so existing configs stay
+  // valid; when omitted the indexer applies the `#no-search-index` default, and
+  // an explicit empty array disables exclusion entirely.
+  excludeTags: z.array(z.string()).optional()
 });
 
 /**
@@ -226,7 +234,10 @@ export function createDefaultConfig(
     },
     collection: {
       name: collectionName,
-      fields: DEFAULT_COLLECTION_FIELDS
+      fields: DEFAULT_COLLECTION_FIELDS,
+      // Canonical convention: a post tagged `#no-search-index` is kept out of
+      // the index. Set to [] to disable, or add your own tags.
+      excludeTags: ['#no-search-index']
     }
   };
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -116,6 +116,14 @@ export const DEFAULT_COLLECTION_FIELDS: CollectionField[] = [
 ];
 
 /**
+ * Default content-policy tag exclusion: a post carrying any of these tags is
+ * kept out of the index. The single source of truth shared by the indexer
+ * (core applies it when `excludeTags` is omitted) and `createDefaultConfig`, so
+ * the default can't drift between explicit-config and default callers.
+ */
+export const DEFAULT_EXCLUDE_TAGS = ['#no-search-index'];
+
+/**
  * Collection configuration schema with strict validation
  */
 export const CollectionConfigSchema = z.object({
@@ -237,7 +245,7 @@ export function createDefaultConfig(
       fields: DEFAULT_COLLECTION_FIELDS,
       // Canonical convention: a post tagged `#no-search-index` is kept out of
       // the index. Set to [] to disable, or add your own tags.
-      excludeTags: ['#no-search-index']
+      excludeTags: [...DEFAULT_EXCLUDE_TAGS]
     }
   };
 }

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -22,11 +22,22 @@ vi.mock('@ts-ghost/content-api', () => {
                   updated_at: '2024-02-09T19:00:00.000Z',
                   tags: [{ name: 'test-tag' }],
                   authors: [{ name: 'Test Author' }]
+                },
+                {
+                  id: 'excluded-bulk-post',
+                  title: 'Excluded Bulk Post',
+                  slug: 'excluded-bulk-post',
+                  html: '<p>Should not be indexed</p>',
+                  excerpt: 'nope',
+                  published_at: '2024-02-09T19:00:00.000Z',
+                  updated_at: '2024-02-09T19:00:00.000Z',
+                  tags: [{ name: '#no-search-index', slug: 'hash-no-search-index' }],
+                  authors: [{ name: 'Test Author' }]
                 }
               ],
               meta: {
                 pagination: {
-                  total: 1,
+                  total: 2,
                   limit: 15
                 }
               }
@@ -445,6 +456,18 @@ describe('GhostTypesenseManager — tag-based exclusion (#no-search-index)', () 
       collection: { ...baseConfig.collection, excludeTags: [] }
     });
     expect(isExcluded(m, { tags: [{ name: '#no-search-index' }] })).toBe(false);
+  });
+
+  it('drops excluded posts from the bulk index (indexAllPosts)', async () => {
+    mockDocuments.import.mockClear();
+    const m = new GhostTypesenseManager(baseConfig);
+    await m.indexAllPosts();
+
+    const importedIds = mockDocuments.import.mock.calls
+      .flatMap((call) => call[0] as Array<{ id: string }>)
+      .map((doc) => doc.id);
+    expect(importedIds).toContain('test-post-1');
+    expect(importedIds).not.toContain('excluded-bulk-post');
   });
 
   // The webhook handler indexes via indexPost; an edit that adds the tag must

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -38,7 +38,23 @@ vi.mock('@ts-ghost/content-api', () => {
         read: ({ id }: { id: string }) => ({
           include: () => ({
             fetch: async () =>
-              id === 'gated-post-1'
+              id === 'excluded-post-1'
+                ? {
+                    success: true,
+                    data: {
+                      id: 'excluded-post-1',
+                      title: 'Landing Page',
+                      slug: 'landing-page',
+                      html: '<p>Marketing copy.</p>',
+                      excerpt: 'Marketing copy.',
+                      visibility: 'public',
+                      published_at: '2024-02-09T19:00:00.000Z',
+                      updated_at: '2024-02-09T19:00:00.000Z',
+                      tags: [{ name: '#no-search-index', slug: 'hash-no-search-index', visibility: 'internal' }],
+                      authors: [{ name: 'Test Author' }]
+                    }
+                  }
+                : id === 'gated-post-1'
                 ? {
                     success: true,
                     data: {
@@ -375,6 +391,83 @@ describe('GhostTypesenseManager — gated content redaction', () => {
       const manager = new GhostTypesenseManager(baseConfig);
       await manager.indexPost('test-post-1');
 
+      expect(mockDocuments.upsert).toHaveBeenCalledTimes(1);
+      expect(mockDocuments.delete).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('GhostTypesenseManager — tag-based exclusion (#no-search-index)', () => {
+  const baseConfig: Config = {
+    ghost: { url: 'https://test.com', key: 'test-key', version: 'v5.0' },
+    typesense: { nodes: [{ host: 'localhost', port: 8108, protocol: 'http' }], apiKey: 'test-key' },
+    collection: {
+      name: 'test-collection',
+      fields: [
+        { name: 'id', type: 'string', optional: false },
+        { name: 'title', type: 'string', optional: false },
+        { name: 'slug', type: 'string', optional: false },
+        { name: 'html', type: 'string', optional: true },
+        { name: 'excerpt', type: 'string', optional: true },
+        { name: 'published_at', type: 'int64', optional: false },
+        { name: 'updated_at', type: 'int64', optional: false }
+      ]
+    }
+  };
+
+  // isExcludedByTag is private; reach it for focused unit tests.
+  function isExcluded(manager: GhostTypesenseManager, post: unknown): boolean {
+    return (manager as unknown as { isExcludedByTag: (p: unknown) => boolean }).isExcludedByTag(post);
+  }
+
+  it('excludes #no-search-index by default, matching tag name or slug (case-insensitive)', () => {
+    const m = new GhostTypesenseManager(baseConfig);
+    expect(isExcluded(m, { tags: [{ name: '#no-search-index', slug: 'hash-no-search-index' }] })).toBe(true);
+    // Defensive: a tag identifiable only by its hash- slug.
+    expect(isExcluded(m, { tags: [{ name: 'Renamed', slug: 'hash-no-search-index' }] })).toBe(true);
+    expect(isExcluded(m, { tags: [{ name: 'Blog', slug: 'blog' }] })).toBe(false);
+    expect(isExcluded(m, {})).toBe(false);
+  });
+
+  it('honours a custom excludeTags list and overrides the default', () => {
+    const m = new GhostTypesenseManager({
+      ...baseConfig,
+      collection: { ...baseConfig.collection, excludeTags: ['Draft'] }
+    });
+    expect(isExcluded(m, { tags: [{ name: 'draft', slug: 'draft' }] })).toBe(true);
+    // Default replaced — #no-search-index no longer excludes.
+    expect(isExcluded(m, { tags: [{ name: '#no-search-index' }] })).toBe(false);
+  });
+
+  it('treats an empty excludeTags array as "exclusion disabled"', () => {
+    const m = new GhostTypesenseManager({
+      ...baseConfig,
+      collection: { ...baseConfig.collection, excludeTags: [] }
+    });
+    expect(isExcluded(m, { tags: [{ name: '#no-search-index' }] })).toBe(false);
+  });
+
+  // The webhook handler indexes via indexPost; an edit that adds the tag must
+  // remove the post from the index rather than upsert it.
+  describe('indexPost (webhook path)', () => {
+    beforeEach(() => {
+      mockDocuments.upsert.mockClear();
+      mockDocuments.delete.mockClear();
+    });
+
+    it('de-indexes a post tagged #no-search-index (delete, not upsert)', async () => {
+      const m = new GhostTypesenseManager(baseConfig);
+      await m.indexPost('excluded-post-1');
+      expect(mockDocuments.upsert).not.toHaveBeenCalled();
+      expect(mockDocuments.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('indexes the same post when excludeTags is set to []', async () => {
+      const m = new GhostTypesenseManager({
+        ...baseConfig,
+        collection: { ...baseConfig.collection, excludeTags: [] }
+      });
+      await m.indexPost('excluded-post-1');
       expect(mockDocuments.upsert).toHaveBeenCalledTimes(1);
       expect(mockDocuments.delete).not.toHaveBeenCalled();
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { TSGhostContentAPI, type Post as GhostPost } from '@ts-ghost/content-api';
 import { Client } from 'typesense';
 import type { CollectionFieldSchema } from 'typesense/lib/Typesense/Collection';
-import type { Config } from '@magicpages/ghost-typesense-config';
+import { type Config, DEFAULT_EXCLUDE_TAGS } from '@magicpages/ghost-typesense-config';
 
 /**
  * A single tag as it appears on a Ghost post, derived from the Content API's
@@ -9,15 +9,6 @@ import type { Config } from '@magicpages/ghost-typesense-config';
  * required) and in sync with the upstream schema.
  */
 type GhostTag = NonNullable<GhostPost['tags']>[number];
-
-/**
- * Default content-policy exclusion: a post tagged `#no-search-index` is kept out
- * of the index. Applied when `collection.excludeTags` is omitted; an explicit
- * `[]` disables exclusion. Kept here (not just in the config default) so every
- * consumer of the package — CLI, webhook handler — shares one canonical
- * convention without each having to opt in.
- */
-const DEFAULT_EXCLUDE_TAGS = ['#no-search-index'];
 
 export interface Post {
   id: string;
@@ -43,10 +34,16 @@ export class GhostTypesenseManager {
   private typesense: Client;
   private config: Config;
   private collectionName: string;
+  // Normalized once at construction (see buildExcludeTagSet) rather than rebuilt
+  // per post during bulk indexing. Empty set = exclusion disabled.
+  private readonly excludeTagSet: Set<string>;
 
   constructor(config: Config) {
     this.config = config;
     this.collectionName = config.collection.name;
+    this.excludeTagSet = GhostTypesenseManager.buildExcludeTagSet(
+      config.collection.excludeTags ?? DEFAULT_EXCLUDE_TAGS
+    );
     this.ghost = new TSGhostContentAPI(
       config.ghost.url,
       config.ghost.key,
@@ -121,35 +118,40 @@ export class GhostTypesenseManager {
   }
 
   /**
-   * Is this post excluded from the index by tag? A publisher marks a post as
-   * non-searchable with a tag (the `#no-search-index` convention by default,
-   * overridable via `collection.excludeTags`). Matching mirrors isInternalTag's
-   * defensive shape — by tag name OR slug, case-insensitively — so the Ghost
-   * internal-tag form (`#no-search-index` / `hash-no-search-index`) is caught
-   * however it was created. The field guards keep a malformed tag from throwing.
+   * Normalize the configured exclusion tags into a lookup set: each value
+   * lowercased, plus the Ghost `hash-` slug form for any `#`-prefixed name — so
+   * `#no-search-index` also matches the slug `hash-no-search-index` even if the
+   * tag's display name was later changed. Built once per manager.
    * @private
    */
-  private isExcludedByTag(post: GhostPost): boolean {
-    const exclude = this.config.collection.excludeTags ?? DEFAULT_EXCLUDE_TAGS;
-    if (exclude.length === 0) return false;
-
-    const tags = post.tags;
-    if (!tags || !Array.isArray(tags) || tags.length === 0) return false;
-
-    // The values to match: each configured tag lowercased, plus the Ghost
-    // `hash-` slug form for any `#`-prefixed name — so `#no-search-index` also
-    // matches the slug `hash-no-search-index` even if the tag's display name was
-    // later changed.
+  private static buildExcludeTagSet(tags: string[]): Set<string> {
     const wanted = new Set<string>();
-    for (const t of exclude) {
+    for (const t of tags) {
       const v = t.toLowerCase();
       wanted.add(v);
       if (v.startsWith('#')) wanted.add(`hash-${v.slice(1)}`);
     }
+    return wanted;
+  }
+
+  /**
+   * Is this post excluded from the index by tag? A publisher marks a post as
+   * non-searchable with a tag (the `#no-search-index` convention by default,
+   * overridable via `collection.excludeTags`). Matching mirrors isInternalTag's
+   * defensive shape — by tag name OR slug, case-insensitively. The field guards
+   * keep a malformed tag from throwing.
+   * @private
+   */
+  private isExcludedByTag(post: GhostPost): boolean {
+    if (this.excludeTagSet.size === 0) return false;
+
+    const tags = post.tags;
+    if (!tags || !Array.isArray(tags) || tags.length === 0) return false;
+
     return tags.some(
       (tag) =>
-        (typeof tag.name === 'string' && wanted.has(tag.name.toLowerCase())) ||
-        (typeof tag.slug === 'string' && wanted.has(tag.slug.toLowerCase()))
+        (typeof tag.name === 'string' && this.excludeTagSet.has(tag.name.toLowerCase())) ||
+        (typeof tag.slug === 'string' && this.excludeTagSet.has(tag.slug.toLowerCase()))
     );
   }
 
@@ -593,7 +595,8 @@ export class GhostTypesenseManager {
     // an edit that *adds* the tag de-indexes the post. Remove any existing
     // document rather than upserting it.
     if (this.isExcludedByTag(post.data)) {
-      await collection.documents().delete({ filter_by: `id:${postId}` }).catch(() => {});
+      await collection.documents().delete({ filter_by: `id:${postId}` })
+        .catch((err: unknown) => console.error(`Failed to de-index excluded post ${postId}:`, err));
       return;
     }
 
@@ -601,7 +604,8 @@ export class GhostTypesenseManager {
     // be indexed. Remove any existing document (e.g. a post that just turned
     // members-only) rather than upserting it.
     if (visibility !== 'public' && !this.config.collection.indexGatedContent) {
-      await collection.documents().delete({ filter_by: `id:${postId}` }).catch(() => {});
+      await collection.documents().delete({ filter_by: `id:${postId}` })
+        .catch((err: unknown) => console.error(`Failed to remove gated post ${postId} from the index:`, err));
       return;
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,15 @@ import type { Config } from '@magicpages/ghost-typesense-config';
  */
 type GhostTag = NonNullable<GhostPost['tags']>[number];
 
+/**
+ * Default content-policy exclusion: a post tagged `#no-search-index` is kept out
+ * of the index. Applied when `collection.excludeTags` is omitted; an explicit
+ * `[]` disables exclusion. Kept here (not just in the config default) so every
+ * consumer of the package — CLI, webhook handler — shares one canonical
+ * convention without each having to opt in.
+ */
+const DEFAULT_EXCLUDE_TAGS = ['#no-search-index'];
+
 export interface Post {
   id: string;
   title: string;
@@ -108,6 +117,39 @@ export class GhostTypesenseManager {
       tag.visibility === 'internal' ||
       (typeof tag.name === 'string' && tag.name.startsWith('#')) ||
       (typeof tag.slug === 'string' && tag.slug.startsWith('hash-'))
+    );
+  }
+
+  /**
+   * Is this post excluded from the index by tag? A publisher marks a post as
+   * non-searchable with a tag (the `#no-search-index` convention by default,
+   * overridable via `collection.excludeTags`). Matching mirrors isInternalTag's
+   * defensive shape — by tag name OR slug, case-insensitively — so the Ghost
+   * internal-tag form (`#no-search-index` / `hash-no-search-index`) is caught
+   * however it was created. The field guards keep a malformed tag from throwing.
+   * @private
+   */
+  private isExcludedByTag(post: GhostPost): boolean {
+    const exclude = this.config.collection.excludeTags ?? DEFAULT_EXCLUDE_TAGS;
+    if (exclude.length === 0) return false;
+
+    const tags = post.tags;
+    if (!tags || !Array.isArray(tags) || tags.length === 0) return false;
+
+    // The values to match: each configured tag lowercased, plus the Ghost
+    // `hash-` slug form for any `#`-prefixed name — so `#no-search-index` also
+    // matches the slug `hash-no-search-index` even if the tag's display name was
+    // later changed.
+    const wanted = new Set<string>();
+    for (const t of exclude) {
+      const v = t.toLowerCase();
+      wanted.add(v);
+      if (v.startsWith('#')) wanted.add(`hash-${v.slice(1)}`);
+    }
+    return tags.some(
+      (tag) =>
+        (typeof tag.name === 'string' && wanted.has(tag.name.toLowerCase())) ||
+        (typeof tag.slug === 'string' && wanted.has(tag.slug.toLowerCase()))
     );
   }
 
@@ -319,11 +361,13 @@ export class GhostTypesenseManager {
       allPosts = allPosts.concat(pageResponse.data);
     }
 
-    // Unless gated indexing is opted into, drop non-public posts so only
-    // public published content is indexed (the default behaviour).
+    // Drop posts the publisher has excluded by tag (e.g. #no-search-index)
+    // first, then — unless gated indexing is opted into — drop non-public posts
+    // so only public published content is indexed (the default behaviour).
+    const indexable = allPosts.filter((post) => !this.isExcludedByTag(post));
     const postsToIndex = this.config.collection.indexGatedContent
-      ? allPosts
-      : allPosts.filter((post) => ((post as { visibility?: string }).visibility || 'public') === 'public');
+      ? indexable
+      : indexable.filter((post) => ((post as { visibility?: string }).visibility || 'public') === 'public');
 
     console.log(`Found ${postsToIndex.length} posts to index (of ${allPosts.length} fetched)`);
     const documents = postsToIndex.map((post) => this.transformPost(post));
@@ -544,6 +588,14 @@ export class GhostTypesenseManager {
 
     const visibility = (post.data as { visibility?: string }).visibility || 'public';
     const collection = this.typesense.collections(this.collectionName);
+
+    // Excluded by tag (e.g. #no-search-index): ensure it isn't in the index, so
+    // an edit that *adds* the tag de-indexes the post. Remove any existing
+    // document rather than upserting it.
+    if (this.isExcludedByTag(post.data)) {
+      await collection.documents().delete({ filter_by: `id:${postId}` }).catch(() => {});
+      return;
+    }
 
     // Respect the opt-in: with gated indexing off, a non-public post must not
     // be indexed. Remove any existing document (e.g. a post that just turned


### PR DESCRIPTION
## What

Adds a configurable, tag-based way to keep individual posts out of the search index — for landing pages, legal/policy pages, internal notes, etc. By default, any post tagged **`#no-search-index`** is excluded.

This is the same category of index-time content policy that already lives in `packages/core` — `isInternalTag()` (exclude internal tags) and `buildRedactedPost()` (redact gated bodies) — so it sits right next to them, as one canonical, documented convention rather than something each consumer reinvents.

## How

- **`collection.excludeTags`** (config) — optional `string[]`; the indexer defaults to `['#no-search-index']` when omitted, and an explicit `[]` disables exclusion.
- **`isExcludedByTag()`** (core) — mirrors `isInternalTag`'s defensive shape: matches a post's tags by **name or slug, case-insensitively**, and derives the Ghost `hash-` slug from `#`-prefixed names (so `#no-search-index` also matches `hash-no-search-index` even if the tag's display name was changed).
- **`indexAllPosts`** filters excluded posts out of the bulk sync.
- **`indexPost`** deletes-and-returns when the tag is present — so through the **webhook handler** (which calls `indexPost`), an edit that *adds* the tag de-indexes the post. No webhook-handler change needed.
- The default lives in core so every consumer (CLI, webhook handler) shares the convention without opting in.

## Tests

- **config:** `excludeTags` undefined when omitted, accepts a custom list, accepts `[]`, and `createDefaultConfig` surfaces the convention.
- **core:** unit tests for `isExcludedByTag` (default match by name/slug, custom list override, `[]` disables), plus `indexPost` integration proving a `#no-search-index` post is **deleted, not upserted** (and indexed normally when `excludeTags: []`).
- Full monorepo green: config 18 · core 20 · search-ui 52 · webhook 5 · cli 3; typecheck 7/7; lint 0 errors.

## Notes

- No version bump here — feature only; bump/release separately when shipping.
- **Convergence (out of scope for this PR):** the package isn't the only indexer. The portal (`apps/api/src/lib/typesense/*`) and an ad-hoc thepulse script each reimplement indexing and have already drifted (the internal-tag leak came from one such fork). Mirroring this exclusion there — ideally converging thepulse onto this package's CLI — is the bigger win and a separate task.

## Summary by Sourcery

Introduce configurable tag-based exclusion of posts from the search index, defaulting to ignoring posts tagged #no-search-index across all core indexer entry points.

New Features:
- Allow collection configs to specify excludeTags so posts with certain tags are omitted from the Typesense search index.
- Default to excluding posts tagged #no-search-index, applied consistently in bulk indexing and single-post indexing paths.

Enhancements:
- Ensure indexPost removes previously indexed documents when a post becomes excluded by tag instead of upserting them.
- Share the #no-search-index exclusion convention via createDefaultConfig so all consumers inherit the same content policy.

Documentation:
- Document tag-based exclusion, including the #no-search-index default and excludeTags configuration, in the README.
- Clarify how tag names and slugs are matched case-insensitively for exclusion.

Tests:
- Add unit and integration tests for tag-based exclusion behaviour, including default #no-search-index handling, custom excludeTags lists, and exclusion disabling with an empty list.
- Extend config tests to cover validation and defaulting for the excludeTags collection option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for excluding individual posts from search indexing using tags, with a default `#no-search-index` convention.
  * Posts with matching tags are now automatically removed from search if they become excluded later.
  * You can now override or disable this behavior with a collection-level exclusion list, including case-insensitive tag matching.

* **Documentation**
  * Expanded the README with guidance on excluding specific posts and how hidden `#`-prefixed tags behave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->