### PR TITLE
chore: release 2.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.8] - 2026-06-27
+
+### Added
+- **Exclude individual posts from search by tag.** Posts carrying a configured
+  tag — `#no-search-index` by default — are kept out of the index entirely, for
+  landing pages, legal/policy pages, or internal notes. Configure with
+  `collection.excludeTags` (an explicit `[]` disables it); values are matched
+  case-insensitively against a post's Ghost tag names and slugs, so the internal
+  tag form (`#no-search-index` / `hash-no-search-index`) is caught however the
+  tag was created. Through the webhook handler, an edit that adds the tag
+  de-indexes the post. Sits alongside the existing internal-tag filtering and
+  gated-content redaction as one canonical, index-time content policy.
+
 ## [2.0.7] - 2026-06-24
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "CLI tool for managing Ghost content in Typesense",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.7",
-    "@magicpages/ghost-typesense-core": "^2.0.7",
+    "@magicpages/ghost-typesense-config": "^2.0.8",
+    "@magicpages/ghost-typesense-core": "^2.0.8",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.7",
-    "@magicpages/ghost-typesense-core": "^2.0.7",
+    "@magicpages/ghost-typesense-config": "^2.0.8",
+    "@magicpages/ghost-typesense-core": "^2.0.8",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.7",
+    "@magicpages/ghost-typesense-config": "^2.0.8",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
Release **2.0.8** — publishes the `#no-search-index` tag exclusion from #52.

- Bumps all packages 2.0.7 → 2.0.8 (`@magicpages` deps re-pinned).
- CHANGELOG entry under `## [2.0.8]`.

After merge, cutting the **`v2.0.8`** GitHub Release triggers `release.yml` to publish all five packages with provenance. This is the version thepulse's reindex needs to gain `#no-search-index` exclusion (internal-tag filtering already shipped in 2.0.4+).