### PR TITLE
fix(search-ui): show a request-failure state instead of "no results"

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -99,6 +99,28 @@ window.__MP_SEARCH_CONFIG__ = {
 | `uiStyle` | `String` | No | `'modal'` | Overall layout: `'modal'`, `'palette'`, or `'discovery'` (see [UI layouts](#ui-layouts)) |
 | `template` | `String` | No | `'list'` | Modal result layout: `'list'` or `'grid'` (see [Result templates](#result-templates)) |
 | `searchAuthors` | `Boolean` | No | `false` | Make author names matchable by keyword (see [Searchable fields](#searchable-fields)) |
+| `connectionTimeoutSeconds` | `Number` | No | `5` | How long a single search request may take before the browser aborts it (see [Connection tuning](#connection-tuning)) |
+| `numRetries` | `Number` | No | typesense-js default | How many times a failed request is retried across your nodes |
+| `retryIntervalSeconds` | `Number` | No | typesense-js default | Pause between those retries |
+
+### Connection tuning
+
+The first search of a reader's session pays DNS + TCP + TLS to your search host before the query itself goes out. On a high-latency or lossy link — a VPN with a distant exit node, patchy mobile — that handshake alone can exhaust a tight budget, and the request is aborted client-side (`ECONNABORTED` in the console) while your search server sits idle.
+
+The default budget is **5 seconds** per request. Raise it if your readers are far from your search host:
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    connectionTimeoutSeconds: 8,
+    numRetries: 3,           // optional — defaults come from typesense-js
+    retryIntervalSeconds: 0.1
+};
+```
+
+All three must be numbers; a non-numeric or out-of-range value is ignored in favour of the default, so a typo can't disable retries or set a zero-second timeout.
+
+When a request does fail, readers see a distinct "Search is temporarily unavailable" panel rather than the no-results message — a failed request is never reported as an empty archive. The error is also logged to the browser console (`MagicPagesSearch: search request failed`), which is the quickest way to tell a connection problem from a genuinely empty result set. Both strings are translatable (`errorMessage`, `errorHint`).
 
 ### Search Fields Configuration
 
@@ -507,7 +529,9 @@ window.__MP_SEARCH_CONFIG__ = {
 | `commonSearchesTitle` | "Common searches" | Heading for common searches section |
 | `emptyStateMessage` | "Start typing to search..." | Message shown when search is empty |
 | `loadingMessage` | "Searching..." | Message shown while searching |
-| `noResultsMessage` | "No results found for your search" | Message when no results found |
+| `noResultsMessage` | "No results found for your search" | Message when a query genuinely matched nothing |
+| `errorMessage` | "Search is temporarily unavailable" | Heading shown when the search request itself failed (timeout, offline, unreachable host) |
+| `errorHint` | "Check your connection and try again." | Second line of that failure state |
 | `navigateHint` | "to navigate" | Keyboard hint for navigation |
 | `closeHint` | "to close" | Keyboard hint for closing |
 | `ariaSearchLabel` | "Search" | ARIA label for search input |
@@ -534,6 +558,8 @@ i18n: {
   emptyStateMessage: 'Beginnen Sie mit der Eingabe...',
   loadingMessage: 'Suche läuft...',
   noResultsMessage: 'Keine Ergebnisse gefunden',
+  errorMessage: 'Die Suche ist gerade nicht verfügbar',
+  errorHint: 'Prüfe deine Verbindung und versuche es erneut.',
   navigateHint: 'zum Navigieren',
   closeHint: 'zum Schließen',
   ariaSearchLabel: 'Suche',
@@ -550,6 +576,8 @@ i18n: {
   emptyStateMessage: 'Comienza a escribir para buscar...',
   loadingMessage: 'Buscando...',
   noResultsMessage: 'No se encontraron resultados',
+  errorMessage: 'La búsqueda no está disponible temporalmente',
+  errorHint: 'Comprueba tu conexión e inténtalo de nuevo.',
   navigateHint: 'para navegar',
   closeHint: 'para cerrar',
   ariaSearchLabel: 'Buscar',
@@ -566,6 +594,8 @@ i18n: {
   emptyStateMessage: 'Commencez à taper pour rechercher...',
   loadingMessage: 'Recherche en cours...',
   noResultsMessage: 'Aucun résultat trouvé',
+  errorMessage: 'La recherche est momentanément indisponible',
+  errorHint: 'Vérifiez votre connexion et réessayez.',
   navigateHint: 'pour naviguer',
   closeHint: 'pour fermer',
   ariaSearchLabel: 'Rechercher',

--- a/packages/search-ui/rollup.config.js
+++ b/packages/search-ui/rollup.config.js
@@ -28,7 +28,10 @@ const plugins = () => [
     format: { comments: false },
     compress: {
       passes: 3,
-      drop_console: true,
+      // Strip development logging, but keep console.error: a failed search
+      // request logs there, and that line is what makes a reader's broken
+      // connection diagnosable from their own browser console.
+      drop_console: ['log', 'info', 'debug', 'warn', 'trace'],
       drop_debugger: true,
       pure_funcs: ['console.log', 'console.info', 'console.debug', 'console.warn'],
       unsafe: true,

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import '../search.js';
 
 // Build an element with shadow content rendered, but without going through
@@ -109,6 +109,48 @@ describe('getSearchParameters — facets', () => {
   it('omits filter_by entirely when no facet is selected and no publisher filter is set', () => {
     const el = mountWithConfig(facetConfig);
     expect(el.getSearchParameters().filter_by).toBeUndefined();
+  });
+});
+
+describe('typesenseClientOptions', () => {
+  it('defaults the connection timeout to 5s (the handshake needs more than 2s on a slow link)', () => {
+    expect(mountWithConfig().typesenseClientOptions().connectionTimeoutSeconds).toBe(5);
+  });
+
+  it('honors a host-configured connectionTimeoutSeconds', () => {
+    const options = mountWithConfig({ connectionTimeoutSeconds: 12 }).typesenseClientOptions();
+    expect(options.connectionTimeoutSeconds).toBe(12);
+  });
+
+  it('falls back to the default for a non-positive or non-numeric timeout', () => {
+    for (const connectionTimeoutSeconds of [0, -1, '8', null, NaN]) {
+      const options = mountWithConfig({ connectionTimeoutSeconds }).typesenseClientOptions();
+      expect(options.connectionTimeoutSeconds).toBe(5);
+    }
+  });
+
+  it('passes numRetries and retryIntervalSeconds through when configured', () => {
+    const options = mountWithConfig({ numRetries: 1, retryIntervalSeconds: 0.5 }).typesenseClientOptions();
+    expect(options.numRetries).toBe(1);
+    expect(options.retryIntervalSeconds).toBe(0.5);
+  });
+
+  it("omits the retry options entirely when unset, keeping typesense-js's own defaults", () => {
+    const options = mountWithConfig().typesenseClientOptions();
+    expect(options).not.toHaveProperty('numRetries');
+    expect(options).not.toHaveProperty('retryIntervalSeconds');
+  });
+
+  it('ignores invalid retry options rather than disabling retries', () => {
+    const options = mountWithConfig({ numRetries: -1, retryIntervalSeconds: '2' }).typesenseClientOptions();
+    expect(options).not.toHaveProperty('numRetries');
+    expect(options).not.toHaveProperty('retryIntervalSeconds');
+  });
+
+  it('carries the node list and search key', () => {
+    const options = mountWithConfig().typesenseClientOptions();
+    expect(options.nodes).toEqual([{ host: 'localhost', port: '8108', protocol: 'http' }]);
+    expect(options.apiKey).toBe('search-only');
   });
 });
 
@@ -272,6 +314,122 @@ describe('facet rendering', () => {
     const el = mountWithConfig({ facets: [{ field: 'tags.name' }] });
     el.renderFacets([]);
     expect(el.facetsContainer.classList.contains('mp-search-hidden')).toBe(true);
+  });
+});
+
+// A failed request must never render the empty state: telling a reader on a
+// timing-out connection that nothing matched their query is what took four
+// rounds of support email to unpick (issue #55).
+describe('request failures', () => {
+  const HIDDEN = 'mp-search-hidden';
+  const clientRejecting = (error) => ({
+    collections: () => ({ documents: () => ({ search: async () => { throw error; } }) })
+  });
+  const clientReturning = (hits) => ({
+    collections: () => ({ documents: () => ({ search: async () => ({ found: hits.length, hits }) }) })
+  });
+  const hit = {
+    document: { id: 'p1', title: 'Composting', url: 'https://x/p/', excerpt: 'How to', published_at: 1700000000000 }
+  };
+
+  let errorLog;
+  beforeEach(() => {
+    errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorLog.mockRestore();
+  });
+
+  it('shows the error state — not the empty state — when the request fails', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientRejecting(new Error('timeout of 5000ms exceeded'));
+
+    await el.handleSearch('composting');
+
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(false);
+    expect(el.emptyState.classList.contains(HIDDEN)).toBe(true);
+    expect(el.loadingState.classList.contains(HIDDEN)).toBe(true);
+    expect(el.hitsList.innerHTML).toBe('');
+    expect(el.hitsList.classList.contains(HIDDEN)).toBe(true);
+  });
+
+  it('logs the underlying error so a broken connection is diagnosable', async () => {
+    const el = mountWithConfig();
+    const failure = new Error('ECONNABORTED timeout of 5000ms exceeded');
+    el.typesenseClient = clientRejecting(failure);
+
+    await el.handleSearch('composting');
+
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining('MagicPagesSearch'), failure);
+  });
+
+  it('still shows the empty state for a query that genuinely matched nothing', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientReturning([]);
+
+    await el.handleSearch('nothing matches this');
+
+    expect(el.emptyState.classList.contains(HIDDEN)).toBe(false);
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(true);
+  });
+
+  it('clears the error state once a later search succeeds', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientRejecting(new Error('offline'));
+    await el.handleSearch('composting');
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(false);
+
+    el.typesenseClient = clientReturning([hit]);
+    await el.handleSearch('composting');
+
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(true);
+    expect(el.hitsList.classList.contains(HIDDEN)).toBe(false);
+    expect(el.hitsList.innerHTML).toContain('Composting');
+  });
+
+  it('emits no analytics events for a request that never completed', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const el = mountWithConfig({ analytics: { endpoint: 'https://e/queries', siteId: 's' } });
+    el.typesenseClient = clientRejecting(new Error('timeout'));
+
+    await el.handleSearch('composting');
+
+    // Reporting a failure as a zero_result would poison the publisher's
+    // "queries with no results" report.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('routes an alternative layout to renderError instead of its empty surface', async () => {
+    const el = mountWithConfig({ uiStyle: 'discovery' });
+    el.activeLayout = {
+      renderLoading: vi.fn(),
+      renderEmpty: vi.fn(),
+      renderError: vi.fn(),
+      renderResults: vi.fn(),
+      renderFacets: vi.fn()
+    };
+    el.typesenseClient = clientRejecting(new Error('timeout'));
+
+    await el.handleSearch('composting');
+
+    expect(el.activeLayout.renderError).toHaveBeenCalledWith('composting');
+    expect(el.activeLayout.renderEmpty).not.toHaveBeenCalled();
+  });
+
+  it('falls back to renderEmpty for a layout chunk that predates renderError', async () => {
+    const el = mountWithConfig({ uiStyle: 'discovery' });
+    el.activeLayout = {
+      renderLoading: vi.fn(),
+      renderEmpty: vi.fn(),
+      renderResults: vi.fn(),
+      renderFacets: vi.fn()
+    };
+    el.typesenseClient = clientRejecting(new Error('timeout'));
+
+    await el.handleSearch('composting');
+
+    expect(el.activeLayout.renderEmpty).toHaveBeenCalledWith('composting');
   });
 });
 

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -60,6 +60,42 @@ function modelWith(featureImage) {
   ];
 }
 
+describe('discovery request-failure state', () => {
+  it('renders an alert with the error strings, not the no-results message', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderError('composting');
+
+    const results = shadow.getElementById('mp-search-discovery-results');
+    const alert = results.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    // makeCtx().t echoes the key, so the keys themselves are the assertion.
+    expect(alert.textContent).toContain('errorMessage');
+    expect(alert.textContent).toContain('errorHint');
+    expect(results.textContent).not.toContain('noResultsMessage');
+  });
+
+  it('collapses the panel to a single column and clears the rail, preview and count', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith(null), { found: 1 });
+    layout.renderError('composting');
+
+    const panel = shadow.getElementById('mp-search-discovery');
+    expect(panel.classList.contains('mp-search-discovery-notice')).toBe(true);
+    expect(shadow.getElementById('mp-search-facets').innerHTML).toBe('');
+    expect(shadow.getElementById('mp-search-discovery-preview').innerHTML).toBe('');
+    expect(shadow.querySelector('.mp-search-discovery-count').textContent).toBe('');
+  });
+
+  it('drops the notice state again once results render', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderError('composting');
+    layout.renderResults(modelWith(null), { found: 1 });
+
+    const panel = shadow.getElementById('mp-search-discovery');
+    expect(panel.classList.contains('mp-search-discovery-notice')).toBe(false);
+  });
+});
+
 describe('discovery preview hero', () => {
   it('omits the hero entirely when the selected result has no feature image', () => {
     const { layout, shadow } = mountDiscovery();

--- a/packages/search-ui/src/__tests__/palette.test.js
+++ b/packages/search-ui/src/__tests__/palette.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import createPaletteLayout from '../layouts/palette.js';
+
+// Hosts mounted during a test, torn down afterwards so DOM fixtures never leak
+// across tests sharing the jsdom environment.
+let mountedHosts = [];
+
+beforeEach(() => {
+  // The palette persists recent searches; start every test from a clean slate.
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  for (const host of mountedHosts) host.remove();
+  mountedHosts = [];
+});
+
+// Minimal layout context. The palette factory only touches the core through
+// this object; for rendering we need the prefix, an HTML-attribute escaper, and
+// the translation helper (echoing the key is enough for assertions).
+function makeCtx() {
+  return {
+    prefix: 'mp-search',
+    escapeHtmlAttr: (v) =>
+      String(v ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;'),
+    t: (k) => k
+  };
+}
+
+function mountPalette() {
+  const layout = createPaletteLayout(makeCtx());
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  mountedHosts.push(host);
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = layout.buildMarkup();
+  layout.cacheElements(shadow);
+  return { layout, shadow };
+}
+
+describe('palette request-failure state', () => {
+  it('renders an alert with the error strings, not the no-results message', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderError('composting');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    const alert = results.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    // makeCtx().t echoes the key, so the keys themselves are the assertion.
+    expect(alert.textContent).toContain('errorMessage');
+    expect(alert.textContent).toContain('errorHint');
+    expect(results.textContent).not.toContain('paletteNoResultsTitle');
+  });
+
+  it('clears the footer status so a stale "Searching…" hint does not linger', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderLoading();
+    expect(shadow.querySelector('.mp-search-palette-status').textContent).toBe('paletteSearching');
+
+    layout.renderError('composting');
+
+    expect(shadow.querySelector('.mp-search-palette-status').textContent).toBe('');
+  });
+
+  it('leaves no navigable rows behind, so Enter cannot open a stale result', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderError('composting');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    expect(results.querySelectorAll('.mp-search-palette-row')).toHaveLength(0);
+    // Enter is only consumed when there is something to activate.
+    expect(layout.handleKeydown({ key: 'Enter', preventDefault() {} })).toBe(false);
+  });
+
+  it('reports zero results for a genuine no-match query (distinct from a failure)', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderEmpty('composting');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    expect(results.textContent).toContain('paletteNoResultsTitle');
+    expect(results.querySelector('[role="alert"]')).toBeNull();
+  });
+});

--- a/packages/search-ui/src/layouts/discovery.css
+++ b/packages/search-ui/src/layouts/discovery.css
@@ -552,14 +552,18 @@
   font-size: calc(0.9375 * var(--mp-rem));
 }
 
-/* Initial state (before any query): collapse the three-pane grid into a single
-   centered column so the empty facet rail and preview pane don't read as broken
-   columns. The welcoming prompt fills the surface instead. */
-.mp-search-discovery-initial .mp-search-discovery-body {
+/* Initial state (before any query) and the notice state (a failed request):
+   collapse the three-pane grid into a single centered column so the empty facet
+   rail and preview pane don't read as broken columns. A full-surface prompt
+   fills the space instead. */
+.mp-search-discovery-initial .mp-search-discovery-body,
+.mp-search-discovery-notice .mp-search-discovery-body {
   grid-template-columns: minmax(0, 1fr);
 }
 .mp-search-discovery-initial .mp-search-discovery-rail,
-.mp-search-discovery-initial .mp-search-discovery-preview {
+.mp-search-discovery-initial .mp-search-discovery-preview,
+.mp-search-discovery-notice .mp-search-discovery-rail,
+.mp-search-discovery-notice .mp-search-discovery-preview {
   display: none;
 }
 

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -63,6 +63,15 @@ export default function createDiscoveryLayout(ctx) {
       + `<span aria-hidden="true">🔒</span> ${esc(ctx.t('membersLabel'))}</span>`;
   }
 
+  // Panel display state. 'initial' (before any query) and 'notice' (a failed
+  // request) both collapse the three-pane grid to a single centred column,
+  // because neither has facets or a preview to show; null restores the grid.
+  function setPanelState(state) {
+    if (!refs.panel) return;
+    refs.panel.classList.toggle(`${P}-discovery-initial`, state === 'initial');
+    refs.panel.classList.toggle(`${P}-discovery-notice`, state === 'notice');
+  }
+
   // ---- Selection ----------------------------------------------------------
 
   function applySelectionClasses() {
@@ -412,7 +421,7 @@ export default function createDiscoveryLayout(ctx) {
     renderInitial() {
       model = [];
       selectedIndex = -1;
-      if (refs.panel) refs.panel.classList.add(`${P}-discovery-initial`);
+      setPanelState('initial');
       if (refs.results) {
         refs.results.innerHTML =
           `<div class="${P}-discovery-prompt">`
@@ -431,7 +440,7 @@ export default function createDiscoveryLayout(ctx) {
     },
 
     renderLoading() {
-      if (refs.panel) refs.panel.classList.remove(`${P}-discovery-initial`);
+      setPanelState(null);
       if (refs.results && model.length === 0) {
         refs.results.innerHTML = `<div class="${P}-discovery-empty">${esc(ctx.t('loadingMessage'))}</div>`;
       }
@@ -440,7 +449,7 @@ export default function createDiscoveryLayout(ctx) {
     renderEmpty(query) {
       model = [];
       selectedIndex = -1;
-      if (refs.panel) refs.panel.classList.remove(`${P}-discovery-initial`);
+      setPanelState(null);
       const q = (query || '').trim();
       if (refs.results) {
         refs.results.innerHTML = `<div class="${P}-discovery-empty">${esc(ctx.t('noResultsMessage'))}</div>`;
@@ -452,9 +461,34 @@ export default function createDiscoveryLayout(ctx) {
       if (refs.count) refs.count.textContent = q ? `0 ${ctx.t('resultsLabel')}` : '';
     },
 
+    // The request failed (timeout, offline, unreachable host). Distinct from
+    // renderEmpty: it fills the surface with an alert rather than reporting zero
+    // results, and clears the rail/preview/count so nothing stale remains.
+    renderError() {
+      model = [];
+      selectedIndex = -1;
+      setPanelState('notice');
+      if (refs.results) {
+        refs.results.innerHTML =
+          `<div class="${P}-discovery-prompt" role="alert">`
+          + `<div class="${P}-discovery-prompt-icon" aria-hidden="true">`
+          + '<svg viewBox="0 0 24 24" width="40" height="40" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">'
+          + '<path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>'
+          + '<line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line>'
+          + '</svg></div>'
+          + `<p class="${P}-discovery-prompt-title">${esc(ctx.t('errorMessage'))}</p>`
+          + `<p class="${P}-discovery-prompt-hint">${esc(ctx.t('errorHint'))}</p>`
+          + '</div>';
+        refs.results.removeAttribute('aria-activedescendant');
+      }
+      if (refs.preview) refs.preview.innerHTML = '';
+      if (refs.facets) refs.facets.innerHTML = '';
+      if (refs.count) refs.count.textContent = '';
+    },
+
     renderResults(nextModel, meta) {
       if (!refs.results) return;
-      if (refs.panel) refs.panel.classList.remove(`${P}-discovery-initial`);
+      setPanelState(null);
 
       // Preserve the selected post (by id) across the re-render where possible;
       // otherwise default to the first hit.

--- a/packages/search-ui/src/layouts/palette.js
+++ b/packages/search-ui/src/layouts/palette.js
@@ -14,8 +14,9 @@
 // Interface (see search.js buildLayoutContext + init): id, requiredFields(),
 // buildMarkup(), cacheElements(root), bindEvents(), onOpen(), onClose(),
 // focusInput(), setQuery(q), getQuery(), setTheme(isDark), renderInitial(),
-// renderLoading(), renderEmpty(query), renderResults(model, meta),
-// renderSuggestions(), renderFacets(counts, selected), handleKeydown(e).
+// renderLoading(), renderEmpty(query), renderError(query),
+// renderResults(model, meta), renderSuggestions(), renderFacets(counts,
+// selected), handleKeydown(e).
 
 const RECENT_KEY = 'mp-search-palette-recent';
 const RECENT_MAX = 5;
@@ -569,6 +570,27 @@ export default function createPaletteLayout(ctx) {
       currentModel = [];
       currentQuery = query || currentQuery;
       renderSurface();
+    },
+
+    // The request failed (timeout, offline, unreachable host) — a different
+    // surface from renderEmpty, which reports a query that matched nothing.
+    // The footer status is cleared so the stale "Searching…" hint goes away and
+    // the alert block is the only message on screen.
+    renderError(query) {
+      currentModel = [];
+      currentFacetCounts = [];
+      currentQuery = query || currentQuery;
+      flatItems = [];
+      activeIndex = 0;
+      if (refs.results) {
+        refs.results.innerHTML = `
+          <div class="${L}-empty" role="alert">
+            <p class="${L}-empty-title">${ctx.t('errorMessage')}</p>
+            <p class="${L}-empty-sub">${ctx.t('errorHint')}</p>
+          </div>`;
+      }
+      applyActive();
+      setStatus('');
     },
 
     renderResults(model, meta) {

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -123,6 +123,13 @@ import Typesense from 'typesense';
     // CSS class prefix to avoid conflicts (kept for consistency)
     const CSS_PREFIX = 'mp-search';
 
+    // Default Typesense client timeout. The first search of a session pays DNS
+    // + TCP + TLS to the search host before the query itself goes out, so a
+    // tighter budget aborts the handshake on a high-latency or lossy link
+    // (a distant VPN exit node is enough). Overridable per site with
+    // `connectionTimeoutSeconds`.
+    const DEFAULT_CONNECTION_TIMEOUT_SECONDS = 5;
+
     // Web Component Definition
     class MagicPagesSearchElement extends HTMLElement {
         constructor() {
@@ -163,6 +170,11 @@ import Typesense from 'typesense';
                 emptyStateMessage: 'Start typing to search...',
                 loadingMessage: 'Searching...',
                 noResultsMessage: 'No results found for your search',
+                // Shown when the search request itself failed (timeout, offline,
+                // unreachable host) — never for a query that genuinely matched
+                // nothing.
+                errorMessage: 'Search is temporarily unavailable',
+                errorHint: 'Check your connection and try again.',
                 navigateHint: 'to navigate',
                 closeHint: 'to close',
                 ariaSearchLabel: 'Search',
@@ -690,6 +702,10 @@ import Typesense from 'typesense';
                                         <p>${this.t('noResultsMessage')}</p>
                                     </div>
                                 </div>
+                                <div id="${CSS_PREFIX}-error" class="${CSS_PREFIX}-error ${CSS_PREFIX}-hidden" role="alert">
+                                    <p class="${CSS_PREFIX}-error-title">${this.t('errorMessage')}</p>
+                                    <p class="${CSS_PREFIX}-error-hint">${this.t('errorHint')}</p>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -710,6 +726,7 @@ import Typesense from 'typesense';
             this.commonSearches = this.shadowRoot.querySelector(`.${CSS_PREFIX}-common-searches`);
             this.loadingState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-loading`);
             this.emptyState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-empty`);
+            this.errorState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-error`);
         }
 
         getCommonSearchesHtml() {
@@ -1027,6 +1044,49 @@ import Typesense from 'typesense';
             }
         }
 
+        // Typesense client options, with the connection budget and retry
+        // behaviour overridable per site. Values must be numbers in a sane
+        // range; anything else falls back to the default (for the timeout) or
+        // to typesense-js's own default (for the retry options), so a typo in
+        // the host's config can never disable retries or set a 0s timeout.
+        typesenseClientOptions() {
+            const { connectionTimeoutSeconds, numRetries, retryIntervalSeconds } = this.config;
+
+            const options = {
+                nodes: this.config.typesenseNodes,
+                apiKey: this.config.typesenseApiKey,
+                connectionTimeoutSeconds: Number.isFinite(connectionTimeoutSeconds) && connectionTimeoutSeconds > 0
+                    ? connectionTimeoutSeconds
+                    : DEFAULT_CONNECTION_TIMEOUT_SECONDS
+            };
+
+            if (Number.isInteger(numRetries) && numRetries >= 0) {
+                options.numRetries = numRetries;
+            }
+            if (Number.isFinite(retryIntervalSeconds) && retryIntervalSeconds >= 0) {
+                options.retryIntervalSeconds = retryIntervalSeconds;
+            }
+
+            return options;
+        }
+
+        // The Typesense client, created on first search and reused afterwards.
+        getTypesenseClient() {
+            if (!this.typesenseClient) {
+                this.typesenseClient = new Typesense.Client(this.typesenseClientOptions());
+            }
+            return this.typesenseClient;
+        }
+
+        // A search request that never completed — timeout, offline, unreachable
+        // host. Logged so a failing connection is diagnosable from the reader's
+        // console (typesense-js logs its own retry warnings; this identifies the
+        // widget as the caller and carries the final error). The reader sees the
+        // translated error state instead, never an empty-results panel.
+        logSearchError(error) {
+            console.error('MagicPagesSearch: search request failed', error);
+        }
+
         async handleSearch(query) {
             query = query?.trim();
 
@@ -1039,6 +1099,7 @@ import Typesense from 'typesense';
                 if (this.hitsList) this.hitsList.classList.add(`${CSS_PREFIX}-hidden`);
                 if (this.commonSearches) this.commonSearches.classList.remove(`${CSS_PREFIX}-hidden`);
                 if (this.emptyState) this.emptyState.classList.add(`${CSS_PREFIX}-hidden`);
+                if (this.errorState) this.errorState.classList.add(`${CSS_PREFIX}-hidden`);
                 if (this.loadingState) this.loadingState.classList.add(`${CSS_PREFIX}-hidden`);
                 if (this.facetsContainer) this.facetsContainer.classList.add(`${CSS_PREFIX}-hidden`);
                 return;
@@ -1049,14 +1110,7 @@ import Typesense from 'typesense';
             if (this.activeLayout) {
                 this.activeLayout.renderLoading();
                 try {
-                    if (!this.typesenseClient) {
-                        this.typesenseClient = new Typesense.Client({
-                            nodes: this.config.typesenseNodes,
-                            apiKey: this.config.typesenseApiKey,
-                            connectionTimeoutSeconds: 2
-                        });
-                    }
-                    const results = await this.typesenseClient
+                    const results = await this.getTypesenseClient()
                         .collections(this.config.collectionName)
                         .documents()
                         .search({ q: query, ...this.getSearchParameters() });
@@ -1075,7 +1129,15 @@ import Typesense from 'typesense';
                     const model = results.hits.map((hit, i) => this.normalizeHit(hit, i));
                     this.activeLayout.renderResults(model, { query, found: resultCount, facetCounts: results.facet_counts });
                 } catch (error) {
-                    this.activeLayout.renderEmpty(query);
+                    this.logSearchError(error);
+                    // A failed request is not an empty archive. Layout chunks
+                    // are fetched separately from the core, so fall back to the
+                    // empty surface for a layout that predates renderError.
+                    if (typeof this.activeLayout.renderError === 'function') {
+                        this.activeLayout.renderError(query);
+                    } else {
+                        this.activeLayout.renderEmpty(query);
+                    }
                 }
                 return;
             }
@@ -1085,24 +1147,16 @@ import Typesense from 'typesense';
             if (this.hitsList) this.hitsList.classList.remove(`${CSS_PREFIX}-hidden`);
             if (this.loadingState) this.loadingState.classList.remove(`${CSS_PREFIX}-hidden`);
             if (this.emptyState) this.emptyState.classList.add(`${CSS_PREFIX}-hidden`);
+            if (this.errorState) this.errorState.classList.add(`${CSS_PREFIX}-hidden`);
 
             try {
-                // Initialize Typesense client if not already initialized
-                if (!this.typesenseClient) {
-                    this.typesenseClient = new Typesense.Client({
-                        nodes: this.config.typesenseNodes,
-                        apiKey: this.config.typesenseApiKey,
-                        connectionTimeoutSeconds: 2
-                    });
-                }
-
                 const searchParams = this.getSearchParameters();
                 const searchParameters = {
                     q: query,
                     ...searchParams
                 };
 
-                const results = await this.typesenseClient
+                const results = await this.getTypesenseClient()
                     .collections(this.config.collectionName)
                     .documents()
                     .search(searchParameters);
@@ -1199,8 +1253,12 @@ import Typesense from 'typesense';
                 this.hitsList.classList.toggle(`${CSS_PREFIX}-grid`, this.config.template === 'grid');
                 this.hitsList.classList.remove(`${CSS_PREFIX}-hidden`);
             } catch (error) {
+                this.logSearchError(error);
+                // The request failed, so show the error state — not the empty
+                // state, which would tell the reader the archive has nothing on
+                // their topic. The empty state was hidden before the request.
                 if (this.loadingState) this.loadingState.classList.add(`${CSS_PREFIX}-hidden`);
-                if (this.emptyState) this.emptyState.classList.remove(`${CSS_PREFIX}-hidden`);
+                if (this.errorState) this.errorState.classList.remove(`${CSS_PREFIX}-hidden`);
                 if (this.hitsList) {
                     this.hitsList.innerHTML = '';
                     this.hitsList.classList.add(`${CSS_PREFIX}-hidden`);

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -683,6 +683,27 @@
     font-size: calc(1 * var(--mp-rem));
 }
 
+/* Request-failure state. Deliberately distinct from the empty state above: a
+   reader whose request never reached the search host must not be told the
+   archive has nothing on their topic. */
+.mp-search-error {
+    padding: calc(2.5 * var(--mp-rem)) calc(1.5 * var(--mp-rem));
+    text-align: center;
+}
+
+.mp-search-error-title {
+    margin: 0;
+    color: var(--color-text);
+    font-size: calc(1 * var(--mp-rem));
+    font-weight: 600;
+}
+
+.mp-search-error-hint {
+    margin: calc(0.375 * var(--mp-rem)) 0 0;
+    color: var(--color-text-secondary);
+    font-size: calc(0.875 * var(--mp-rem));
+}
+
 /* Close button */
 .mp-search-close {
     position: fixed;


### PR DESCRIPTION
Every search failure — timeout, offline, unreachable host — rendered the same panel as a genuine zero-hit query, so a reader on a slow or lossy connection was told the archive had nothing on their topic while the search server sat idle. The error was swallowed with no trace anywhere, which is why the reported case took four rounds of support email to pin on the connection.

Failures now render their own state ("Search is temporarily unavailable" + "Check your connection and try again."), separate from the no-results panel, in all three layouts: a role=alert block in the modal, an alert surface in the palette (with the stale "Searching…" status cleared), and a full-surface prompt in discovery (the facet rail and preview collapse, as in the initial state). Both strings are translatable via errorMessage / errorHint. The underlying error is logged as `MagicPagesSearch: search request failed`, so the next failing connection is diagnosable from the reader's own console — terser now keeps console.error while still dropping log/info/debug/warn.

The client's hardcoded 2s connectionTimeoutSeconds becomes configurable and defaults to 5s. The first search of a session pays DNS + TCP + TLS before the query goes out, and 2s could not cover that handshake on a distant or lossy link. numRetries and retryIntervalSeconds are exposed the same way; all three are validated, so a typo falls back to the default rather than disabling retries or setting a zero-second timeout. Client construction moves into one getTypesenseClient() used by both the modal and layout paths.

Closes #55