### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-08-04
+
+### Fixed
+- **Failed search requests were shown to readers as "No results found".** Every
+  error — a timed-out request, an offline reader, an unreachable search host —
+  rendered the same panel as a query that genuinely matched nothing, so a reader
+  on a slow or high-latency connection was told the archive had nothing on their
+  topic while the search server sat idle. The error was swallowed with no trace
+  anywhere, which is why one reported case took four rounds of support email to
+  pin on the connection rather than the index. Failures now render their own
+  state — "Search is temporarily unavailable" / "Check your connection and try
+  again." — in all three layouts: a `role="alert"` block in the modal, an alert
+  surface in the palette (with the stale "Searching…" status cleared), and a
+  full-surface prompt in discovery (where the facet rail and preview collapse,
+  as they do in the initial state). Both strings are translatable through the
+  new `errorMessage` and `errorHint` i18n keys. The underlying error is now
+  logged as `MagicPagesSearch: search request failed`, so the next failing
+  connection is diagnosable from the reader's own browser console. Search-ui
+  bundle change — publishing refreshes the CDN; redeploy the rebuilt bundle to
+  sites.
+
+### Added
+- **The search client's connection budget is configurable.**
+  `connectionTimeoutSeconds` in `window.__MP_SEARCH_CONFIG__` replaces a
+  hardcoded 2 s timeout, and now defaults to 5 s. The first search of a session
+  pays DNS + TCP + TLS to the search host before the query itself goes out, and
+  2 s could not cover that handshake on a lossy link or a VPN with a distant
+  exit node — the request was aborted client-side while the backend was idle.
+  `numRetries` and `retryIntervalSeconds` are exposed the same way, falling back
+  to typesense-js's own defaults when unset. All three are validated, so a typo
+  in a site's config can't disable retries or set a zero-second timeout.
+
 ## [2.0.8] - 2026-06-27
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "CLI tool for managing Ghost content in Typesense",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.8",
-    "@magicpages/ghost-typesense-core": "^2.0.8",
+    "@magicpages/ghost-typesense-config": "^2.1.0",
+    "@magicpages/ghost-typesense-core": "^2.1.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.8",
-    "@magicpages/ghost-typesense-core": "^2.0.8",
+    "@magicpages/ghost-typesense-config": "^2.1.0",
+    "@magicpages/ghost-typesense-core": "^2.1.0",
     "@netlify/functions": "^2.5.1",
     "zod": "^3.22.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -31,11 +31,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.5",
-        "@magicpages/ghost-typesense-core": "^2.0.5",
+        "@magicpages/ghost-typesense-config": "^2.1.0",
+        "@magicpages/ghost-typesense-core": "^2.1.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ora": "^8.0.1"
@@ -144,11 +144,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.5",
-        "@magicpages/ghost-typesense-core": "^2.0.5",
+        "@magicpages/ghost-typesense-config": "^2.1.0",
+        "@magicpages/ghost-typesense-core": "^2.1.0",
         "@netlify/functions": "^2.5.1",
         "zod": "^3.22.4"
       },
@@ -9159,7 +9159,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -9241,10 +9241,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.0.5",
+        "@magicpages/ghost-typesense-config": "^2.1.0",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "typesense": "^1.7.2",
@@ -9323,7 +9323,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -10058,8 +10058,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.5",
-        "@magicpages/ghost-typesense-core": "^2.0.5",
+        "@magicpages/ghost-typesense-config": "^2.1.0",
+        "@magicpages/ghost-typesense-core": "^2.1.0",
         "@types/node": "^20.11.17",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -10166,7 +10166,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.5",
+        "@magicpages/ghost-typesense-config": "^2.1.0",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^4.0.6",
         "@types/node": "^20.11.17",
@@ -10285,8 +10285,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.0.5",
-        "@magicpages/ghost-typesense-core": "^2.0.5",
+        "@magicpages/ghost-typesense-config": "^2.1.0",
+        "@magicpages/ghost-typesense-core": "^2.1.0",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^20.11.17",
         "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.0.8",
+    "@magicpages/ghost-typesense-config": "^2.1.0",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^4.0.6",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
Cuts 2.1.0, publishing the request-failure fix from #56 (issue #55).

## What's in it

**Fixed — failed search requests were shown to readers as "No results found".**
Every error (timeout, offline reader, unreachable search host) rendered the same panel as a query that genuinely matched nothing, and was swallowed with no trace anywhere. Failures now render their own state — "Search is temporarily unavailable" / "Check your connection and try again." — in all three layouts, and the underlying error is logged as `MagicPagesSearch: search request failed` so the next failing connection is diagnosable from the reader's own console.

**Added — the client's connection budget is configurable.**
`connectionTimeoutSeconds` replaces the hardcoded 2 s timeout and defaults to 5 s; `numRetries` and `retryIntervalSeconds` are exposed the same way. Two new i18n keys (`errorMessage`, `errorHint`). New config surface is why this is a minor rather than a patch.

## This PR

- All packages bumped to 2.1.0 (`scripts/bump-versions.js` equivalent).
- CHANGELOG entry with both sections.
- `package-lock.json` brought back in sync — it had been left at 2.0.5 since that release.

Repo-wide `lint`, `typecheck`, `test` (120 tests), and `build` all pass locally.

## After merging

Draft a GitHub Release with tag `v2.1.0` to trigger `release.yml`: it publishes every package to npm via trusted publishing, which makes the unpkg / jsDelivr URLs live, then dispatches to customer-portal so it opens its own bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search failures now show dedicated error states in modal, palette, and discovery views.
  - Error messages are available for translation.
  - Search connection timeout and retry settings can now be configured and validated.
  - A 5-second timeout is provided by default.

- **Documentation**
  - Added release notes for version 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->