### PR TITLE
Implement enableDidYouMean as a spelling-correction prompt

### DIFF
--- a/apps/playground/src/mock.js
+++ b/apps/playground/src/mock.js
@@ -1,8 +1,9 @@
 // A small fake Ghost dataset and a minimal Typesense-shaped search responder,
 // so the playground demonstrates the widget offline. This is intentionally not
 // a Typesense reimplementation — it honours just enough (`q` substring match,
-// `filter_by` facet equality, `facet_by` counts, basic highlighting) to make
-// the search, suggestions, facet, and grid features visible.
+// `filter_by` facet equality, `facet_by` counts, basic highlighting, and
+// `num_typos` word matching) to make the search, suggestions, facet, grid, and
+// did-you-mean features visible.
 
 export const POSTS = [
   {
@@ -109,12 +110,68 @@ function matchesFilters(post, filters) {
   });
 }
 
-function highlight(text, q) {
-  if (!q) return { snippet: text };
+// Word-level matching, mirroring the two things the widget relies on: prefix
+// matching (`prefix: true`) and a per-word typo budget (`num_typos`). The typo
+// side is only ever reached when the widget asks for it, which is what makes
+// the did-you-mean retry demonstrable offline: the strict first request finds
+// nothing, the lenient second one matches. `queryWord` comes in lowercased
+// (see queryWords); the document's own casing is preserved for the caller.
+function wordMatches(docWord, queryWord, budget) {
+  const word = docWord.toLowerCase();
+  if (word.startsWith(queryWord)) return true;
+  if (budget <= 0 || Math.abs(word.length - queryWord.length) > budget) return false;
+
+  // Levenshtein distance, abandoned once it is known to exceed the budget.
+  let previous = Array.from({ length: word.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= queryWord.length; i++) {
+    const current = [i];
+    let rowMin = i;
+    for (let j = 1; j <= word.length; j++) {
+      const cost = queryWord[i - 1] === word[j - 1] ? 0 : 1;
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + cost);
+      if (current[j] < rowMin) rowMin = current[j];
+    }
+    if (rowMin > budget) return false;
+    previous = current;
+  }
+  return previous[word.length] <= budget;
+}
+
+function words(text) {
+  return String(text).match(/[\p{L}\p{N}']+/gu) || [];
+}
+
+function queryWords(q) {
+  return q.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+// Every query word has to match some word in the text — the mock's stand-in for
+// a typo-tolerant match, used only when the widget asked for one.
+function matchesWithTypos(text, q, budget) {
+  const docWords = words(text);
+  return queryWords(q).every((queryWord) =>
+    docWords.some((docWord) => wordMatches(docWord, queryWord, budget))
+  );
+}
+
+// The document's own words that the query matched. The widget reads these as
+// `matched_tokens` — they are where a "did you mean" correction comes from, so
+// they carry the document's spelling rather than the reader's.
+function matchedTokens(text, q, budget) {
+  if (!q) return [];
+  const qWords = queryWords(q);
+  return words(text).filter((docWord) =>
+    qWords.some((queryWord) => wordMatches(docWord, queryWord, budget))
+  );
+}
+
+function highlight(text, q, budget) {
+  const matched_tokens = matchedTokens(text, q, budget);
+  if (!q) return { snippet: text, matched_tokens };
   const idx = text.toLowerCase().indexOf(q.toLowerCase());
-  if (idx === -1) return { snippet: text };
+  if (idx === -1) return { snippet: text, matched_tokens };
   const snippet = `${text.slice(0, idx)}<mark>${text.slice(idx, idx + q.length)}</mark>${text.slice(idx + q.length)}`;
-  return { snippet };
+  return { snippet, matched_tokens };
 }
 
 // The indexed representation of a post, mirroring what packages/core writes to
@@ -134,6 +191,8 @@ function toIndexedDoc(post) {
 
 export function mockSearchResponse(params = {}) {
   const q = (params.q || '').trim();
+  // Arrives as a query-string value, so it is a string on the wire.
+  const numTypos = Number(params.num_typos) || 0;
   const filters = parseFilterBy(params.filter_by);
   const facetBy = (params.facet_by || '').split(',').map((f) => f.trim()).filter(Boolean);
 
@@ -152,15 +211,18 @@ export function mockSearchResponse(params = {}) {
     if (!q || q === '*') return true;
     const fieldsText = [p.title, p.excerpt, p.plaintext, p.tags.join(' ')];
     if (includeAuthors) fieldsText.push((p.authors || []).join(' '));
-    const haystack = fieldsText.join(' ').toLowerCase();
-    return haystack.includes(q.toLowerCase());
+    const haystack = fieldsText.join(' ');
+    if (haystack.toLowerCase().includes(q.toLowerCase())) return true;
+    // Only when the widget asked for typo tolerance, so the strict default
+    // keeps matching exactly as before.
+    return numTypos > 0 && matchesWithTypos(haystack, q, numTypos);
   });
 
   const hits = filtered.map((document) => ({
     document,
     highlight: {
-      title: highlight(document.title, q),
-      excerpt: highlight(document.excerpt, q)
+      title: highlight(document.title, q, numTypos),
+      excerpt: highlight(document.excerpt, q, numTypos)
     }
   }));
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -138,7 +138,7 @@ Picking it runs the corrected search. Clicking works everywhere; in the palette 
 
 The suggested word comes from the `matched_tokens` the retry returned, so it is always a word your posts actually contain — never a guess from a dictionary that doesn't know your archive. Words are only replaced within the typo budget Typesense itself would allow for their length (nothing under four characters, one typo up to six, two beyond), and a query whose words are all in the index is left alone rather than being offered back unchanged.
 
-The retry is skipped entirely when your `typesenseSearchParams` already set a non-zero `num_typos` — you are searching leniently already, so the first request was the lenient one. So strict-matching sites pay one extra request, and only on a genuine miss; lenient ones pay none. If the retry fails or finds nothing, the reader simply keeps the ordinary empty state.
+The retry is skipped entirely when your `typesenseSearchParams` already sets a non-zero `num_typos` — you are searching leniently already, so the first request was the lenient one. So strict-matching sites pay one extra request, and only on a genuine miss; lenient ones pay none. If the retry fails or finds nothing, the reader simply keeps the ordinary empty state.
 
 Turn it off with:
 
@@ -149,7 +149,7 @@ window.__MP_SEARCH_CONFIG__ = {
 };
 ```
 
-The prompt's wording is translatable via `didYouMeanLabel` (see [Internationalization](#internationalization-i18n)).
+The prompt's wording is translatable via `didYouMeanLabel`, where `{q}` marks where the suggested term goes (see [Internationalization](#internationalization-i18n)). The string is rendered as text — markup in a translation shows up literally rather than being parsed.
 
 ### Search Fields Configuration
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -16,6 +16,7 @@ A beautiful, accessible search interface for Ghost blogs using Typesense. This p
 - 🔎 Smart context-aware search result highlighting
 - 📝 Plaintext content search for improved relevance
 - 💡 Exact phrase matching support
+- 🪄 "Did you mean …?" spelling correction on a query that matched nothing
 - 🔍 Contextual excerpts that show search term in context
 - 🧩 Support for nested fields
 - 🛡️ **Style encapsulation with Web Components** - Uses Shadow DOM to prevent Ghost theme styles from interfering with the search UI
@@ -82,6 +83,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `collectionName` | `String` | Yes | — | Name of your Typesense collection |
 | `theme` | `String` | No | `'system'` | UI theme: `'light'`, `'dark'`, or `'system'` (respects OS preference) |
 | `enableHighlighting` | `Boolean` | No | `true` | Whether to highlight search terms in results |
+| `enableDidYouMean` | `Boolean` | No | `true` | Offer a corrected term when a query matches nothing (see [Spelling correction](#spelling-correction)) |
 | `commonSearches` | `Array` | No | `[]` | Static fallback list of suggested search terms (see [Search suggestions](#search-suggestions)) |
 | `pinnedSearches` | `Array` | No | `[]` | Publisher-curated terms, always shown first (see [Search suggestions](#search-suggestions)) |
 | `suggestionsUrl` | `String` | No | — | URL fetched on modal open for dynamic suggestions (see [Search suggestions](#search-suggestions)) |
@@ -121,6 +123,33 @@ window.__MP_SEARCH_CONFIG__ = {
 All three must be numbers; a non-numeric or out-of-range value is ignored in favour of the default, so a typo can't disable retries or set a zero-second timeout.
 
 When a request does fail, readers see a distinct "Search is temporarily unavailable" panel rather than the no-results message — a failed request is never reported as an empty archive. The error is also logged to the browser console (`MagicPagesSearch: search request failed`), which is the quickest way to tell a connection problem from a genuinely empty result set. Both strings are translatable (`errorMessage`, `errorHint`).
+
+### Spelling correction
+
+Search matches strictly by default (`num_typos: 0`), which is what keeps results predictable — a query returns the posts that contain the words, not their near-neighbours. The cost is that a mistyped word matches nothing at all.
+
+`enableDidYouMean` covers that case. When a query returns zero results, the widget re-runs it once with typo tolerance raised (`num_typos: 2`). If that finds posts, the reader is offered the corrected term:
+
+> No results found for your search
+>
+> **Did you mean _composting_?**
+
+Picking it runs the corrected search. Clicking works everywhere; in the palette layout the prompt is also a row, so `↵` accepts it.
+
+The suggested word comes from the `matched_tokens` the retry returned, so it is always a word your posts actually contain — never a guess from a dictionary that doesn't know your archive. Words are only replaced within the typo budget Typesense itself would allow for their length (nothing under four characters, one typo up to six, two beyond), and a query whose words are all in the index is left alone rather than being offered back unchanged.
+
+The retry is skipped entirely when your `typesenseSearchParams` already set a non-zero `num_typos` — you are searching leniently already, so the first request was the lenient one. So strict-matching sites pay one extra request, and only on a genuine miss; lenient ones pay none. If the retry fails or finds nothing, the reader simply keeps the ordinary empty state.
+
+Turn it off with:
+
+```javascript
+window.__MP_SEARCH_CONFIG__ = {
+    // ... required config
+    enableDidYouMean: false
+};
+```
+
+The prompt's wording is translatable via `didYouMeanLabel` (see [Internationalization](#internationalization-i18n)).
 
 ### Search Fields Configuration
 
@@ -530,6 +559,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `emptyStateMessage` | "Start typing to search..." | Message shown when search is empty |
 | `loadingMessage` | "Searching..." | Message shown while searching |
 | `noResultsMessage` | "No results found for your search" | Message when a query genuinely matched nothing |
+| `didYouMeanLabel` | "Did you mean {q}?" | Spelling-correction prompt under the empty state (`{q}` is the suggested term) |
 | `errorMessage` | "Search is temporarily unavailable" | Heading shown when the search request itself failed (timeout, offline, unreachable host) |
 | `errorHint` | "Check your connection and try again." | Second line of that failure state |
 | `navigateHint` | "to navigate" | Keyboard hint for navigation |

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -824,3 +824,161 @@ describe('did you mean', () => {
     expect(el.activeLayout.renderError).not.toHaveBeenCalled();
   });
 });
+
+// Two searches can be in flight at once — the 80ms debounce narrows the window
+// but does not close it. Whichever request returns last used to win the surface,
+// so a slow early query could repaint over the results of the query the reader
+// is actually looking at.
+describe('superseded searches', () => {
+  const HIDDEN = 'mp-search-hidden';
+
+  const hit = {
+    document: { id: 'p1', title: 'Composting', url: 'https://x/p/', excerpt: 'How to', published_at: 1700000000000 }
+  };
+
+  // A backend whose per-query responses resolve when the test says so.
+  const deferredClient = (responders) => ({
+    collections: () => ({
+      documents: () => ({
+        search: (params) => responders[params.q]()
+      })
+    })
+  });
+
+  const deferred = () => {
+    let settle;
+    const promise = new Promise((resolve, reject) => { settle = { resolve, reject }; });
+    return { promise, ...settle };
+  };
+
+  it('does not let an earlier empty response wipe the newer query\'s results', async () => {
+    const slow = deferred();
+    const el = mountWithConfig();
+    el.typesenseClient = deferredClient({
+      compost: () => slow.promise,
+      composting: () => Promise.resolve({ found: 1, hits: [hit] })
+    });
+
+    const first = el.handleSearch('compost');
+    await el.handleSearch('composting');
+    expect(el.hitsList.innerHTML).toContain('Composting');
+
+    slow.resolve({ found: 0, hits: [] });
+    await first;
+
+    expect(el.hitsList.classList.contains(HIDDEN)).toBe(false);
+    expect(el.hitsList.innerHTML).toContain('Composting');
+    expect(el.emptyState.classList.contains(HIDDEN)).toBe(true);
+  });
+
+  it('does not let an earlier failure raise the error state over newer results', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const slow = deferred();
+    const el = mountWithConfig();
+    el.typesenseClient = deferredClient({
+      compost: () => slow.promise,
+      composting: () => Promise.resolve({ found: 1, hits: [hit] })
+    });
+
+    const first = el.handleSearch('compost');
+    await el.handleSearch('composting');
+
+    slow.reject(new Error('timeout'));
+    await first;
+
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(true);
+    expect(el.hitsList.innerHTML).toContain('Composting');
+    // The failure is still logged — a broken connection is worth a trace even
+    // when its query has been typed past.
+    expect(errorLog).toHaveBeenCalled();
+    errorLog.mockRestore();
+  });
+
+  it('attributes clicks and analytics to the query actually on screen', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const slow = deferred();
+    const el = mountWithConfig({ analytics: { endpoint: 'https://e/queries', siteId: 's' } });
+    el.typesenseClient = deferredClient({
+      compost: () => slow.promise,
+      composting: () => Promise.resolve({ found: 1, hits: [hit] })
+    });
+
+    const first = el.handleSearch('compost');
+    await el.handleSearch('composting');
+    slow.resolve({ found: 4, hits: [hit] });
+    await first;
+
+    expect(el.lastQuery).toBe('composting');
+    const queries = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body).q);
+    expect(queries).not.toContain('compost');
+  });
+
+  it('keeps the same guard on the alternative-layout path', async () => {
+    const slow = deferred();
+    const el = mountWithConfig({ uiStyle: 'discovery' });
+    el.activeLayout = {
+      renderLoading: vi.fn(),
+      renderEmpty: vi.fn(),
+      renderError: vi.fn(),
+      renderResults: vi.fn(),
+      renderFacets: vi.fn()
+    };
+    el.typesenseClient = deferredClient({
+      compost: () => slow.promise,
+      composting: () => Promise.resolve({ found: 1, hits: [hit] })
+    });
+
+    const first = el.handleSearch('compost');
+    await el.handleSearch('composting');
+    slow.resolve({ found: 0, hits: [] });
+    await first;
+
+    expect(el.activeLayout.renderResults).toHaveBeenCalledTimes(1);
+    expect(el.activeLayout.renderEmpty).not.toHaveBeenCalled();
+  });
+});
+
+// The prompt's wording is a translation from the site's own config. Its text is
+// escaped like any other string; only the wrapper around the suggested term is
+// markup — the same contract in all three layouts.
+describe('did-you-mean label contract', () => {
+  const matching = (...tokens) => ({
+    document: { id: 'p1', title: 'Composting', url: 'https://x/p/', excerpt: 'e', published_at: 1700000000000 },
+    highlight: { title: { matched_tokens: tokens, snippet: '' } }
+  });
+
+  const clientTolerating = (typoHits) => ({
+    collections: () => ({
+      documents: () => ({
+        search: async (params) => {
+          const hits = Number(params.num_typos) > 0 ? typoHits : [];
+          return { found: hits.length, hits };
+        }
+      })
+    })
+  });
+
+  it('substitutes {q} in a translated label', async () => {
+    const el = mountWithConfig();
+    el.i18n = { ...el.defaultI18n, didYouMeanLabel: 'Meintest du {q}?' };
+    el.typesenseClient = clientTolerating([matching('composting')]);
+
+    await el.handleSearch('compsting');
+
+    const button = el.didYouMeanState.querySelector('.mp-search-did-you-mean-btn');
+    expect(button.textContent).toBe('Meintest du composting?');
+    expect(button.querySelector('.mp-search-did-you-mean-term').textContent).toBe('composting');
+  });
+
+  it('renders a label containing markup as text, never as markup', async () => {
+    const el = mountWithConfig();
+    el.i18n = { ...el.defaultI18n, didYouMeanLabel: '<img src=x onerror=alert(1)> {q}?' };
+    el.typesenseClient = clientTolerating([matching('composting')]);
+
+    await el.handleSearch('compsting');
+
+    expect(el.didYouMeanState.querySelector('img')).toBeNull();
+    expect(el.didYouMeanState.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -607,3 +607,220 @@ describe('highlight snippet selection', () => {
     expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
   });
 });
+
+// enableDidYouMean. The widget matches strictly (num_typos: 0) so results stay
+// predictable, which leaves a mistyped query with nowhere to go. One typo-
+// tolerant retry on a genuine miss turns that dead end into an offer.
+describe('did you mean', () => {
+  const HIDDEN = 'mp-search-hidden';
+
+  const hit = (title) => ({
+    document: { id: 'p1', title, url: 'https://x/p/', excerpt: 'e', published_at: 1700000000000 }
+  });
+
+  const matching = (...tokens) => ({
+    ...hit('Composting'),
+    highlight: { title: { matched_tokens: tokens, snippet: '' } }
+  });
+
+  // A backend that finds nothing as typed but matches `typoHits` once the
+  // retry raises num_typos — the shape of a real misspelling.
+  const clientTolerating = (typoHits, calls = []) => ({
+    collections: () => ({
+      documents: () => ({
+        search: async (params) => {
+          calls.push(params);
+          const hits = Number(params.num_typos) > 0 ? typoHits : [];
+          return { found: hits.length, hits };
+        }
+      })
+    })
+  });
+
+  it('offers the term the index holds when the query matched nothing as typed', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([matching('composting')]);
+
+    await el.handleSearch('compsting');
+
+    expect(el.emptyState.classList.contains(HIDDEN)).toBe(false);
+    expect(el.didYouMeanState.classList.contains(HIDDEN)).toBe(false);
+    const button = el.didYouMeanState.querySelector('.mp-search-did-you-mean-btn');
+    expect(button.dataset.search).toBe('composting');
+    expect(button.textContent).toBe('Did you mean composting?');
+  });
+
+  it('costs exactly one extra request, and only on a genuine miss', async () => {
+    const calls = [];
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([matching('composting')], calls);
+
+    await el.handleSearch('compsting');
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].num_typos).toBe(0);
+    expect(calls[1].num_typos).toBe(2);
+    // The retry keeps every other parameter, so the suggestion respects the
+    // publisher's filters and the reader's facet selection.
+    expect(calls[1].query_by).toBe(calls[0].query_by);
+  });
+
+  it('does not retry a query that already returned results', async () => {
+    const calls = [];
+    const el = mountWithConfig();
+    el.typesenseClient = {
+      collections: () => ({
+        documents: () => ({
+          search: async (params) => {
+            calls.push(params);
+            return { found: 1, hits: [hit('Composting')] };
+          }
+        })
+      })
+    };
+
+    await el.handleSearch('composting');
+
+    expect(calls).toHaveLength(1);
+    expect(el.didYouMeanState.innerHTML).toBe('');
+  });
+
+  it('skips the retry for a host that already searches with typo tolerance', async () => {
+    // Their first request was the lenient one; repeating it would find the
+    // same nothing at the cost of a second round trip.
+    const calls = [];
+    const el = mountWithConfig({ typesenseSearchParams: { num_typos: 1 } });
+    el.typesenseClient = clientTolerating([matching('composting')], calls);
+
+    await el.handleSearch('compsting');
+
+    expect(calls).toHaveLength(1);
+    expect(el.didYouMeanState.classList.contains(HIDDEN)).toBe(true);
+  });
+
+  it('skips the retry when the option is turned off', async () => {
+    const calls = [];
+    const el = mountWithConfig({ enableDidYouMean: false });
+    el.typesenseClient = clientTolerating([matching('composting')], calls);
+
+    await el.handleSearch('compsting');
+
+    expect(calls).toHaveLength(1);
+    expect(el.didYouMeanState.innerHTML).toBe('');
+  });
+
+  it('keeps the plain empty state when the retry also finds nothing', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([]);
+
+    await el.handleSearch('nothing like this exists');
+
+    expect(el.emptyState.classList.contains(HIDDEN)).toBe(false);
+    expect(el.didYouMeanState.classList.contains(HIDDEN)).toBe(true);
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(true);
+  });
+
+  it('leaves the empty state alone when the retry itself fails', async () => {
+    // A failed second request is not the reader's problem: they are already
+    // looking at a valid empty result, and an error panel would contradict it.
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = mountWithConfig();
+    el.typesenseClient = {
+      collections: () => ({
+        documents: () => ({
+          search: async (params) => {
+            if (Number(params.num_typos) > 0) throw new Error('timeout');
+            return { found: 0, hits: [] };
+          }
+        })
+      })
+    };
+
+    await el.handleSearch('compsting');
+
+    expect(el.emptyState.classList.contains(HIDDEN)).toBe(false);
+    expect(el.errorState.classList.contains(HIDDEN)).toBe(true);
+    expect(el.didYouMeanState.innerHTML).toBe('');
+    errorLog.mockRestore();
+  });
+
+  it('drops a suggestion whose query the reader has already typed past', async () => {
+    // The retry lands a request later than the search it belongs to. Bumping
+    // the sequence stands in for that newer query having been issued meanwhile.
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([matching('composting')]);
+
+    const pending = el.handleSearch('compsting');
+    el.searchSequence += 1;
+    await pending;
+
+    expect(el.didYouMeanState.innerHTML).toBe('');
+  });
+
+  it('clears a previous suggestion before the next query can produce one', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([matching('composting')]);
+    await el.handleSearch('compsting');
+    expect(el.didYouMeanState.innerHTML).not.toBe('');
+
+    el.typesenseClient = clientTolerating([]);
+    await el.handleSearch('mulching techniques');
+
+    expect(el.didYouMeanState.innerHTML).toBe('');
+  });
+
+  it('escapes a suggested term so an indexed value cannot inject markup', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([matching('"><img src=x onerror=alert(1)>')]);
+
+    await el.handleSearch('"><img src=y onerror=alert(2)>');
+
+    expect(el.didYouMeanState.innerHTML).not.toContain('<img');
+  });
+
+  it('runs the corrected search when the prompt is clicked', async () => {
+    const el = mountWithConfig();
+    el.typesenseClient = clientTolerating([matching('composting')]);
+    el.initEventListeners();
+
+    await el.handleSearch('compsting');
+    el.didYouMeanState.querySelector('.mp-search-did-you-mean-btn').click();
+
+    expect(el.searchInput.value).toBe('composting');
+  });
+
+  it('hands the suggestion to an alternative layout instead of the modal DOM', async () => {
+    const el = mountWithConfig({ uiStyle: 'palette' });
+    el.activeLayout = {
+      renderLoading: vi.fn(),
+      renderEmpty: vi.fn(),
+      renderError: vi.fn(),
+      renderResults: vi.fn(),
+      renderFacets: vi.fn(),
+      renderDidYouMean: vi.fn()
+    };
+    el.typesenseClient = clientTolerating([matching('composting')]);
+
+    await el.handleSearch('compsting');
+
+    expect(el.activeLayout.renderEmpty).toHaveBeenCalledWith('compsting');
+    expect(el.activeLayout.renderDidYouMean).toHaveBeenCalledWith('composting');
+  });
+
+  it('leaves a layout chunk that predates the prompt with its plain empty surface', async () => {
+    const el = mountWithConfig({ uiStyle: 'palette' });
+    el.activeLayout = {
+      renderLoading: vi.fn(),
+      renderEmpty: vi.fn(),
+      renderError: vi.fn(),
+      renderResults: vi.fn(),
+      renderFacets: vi.fn()
+    };
+    el.typesenseClient = clientTolerating([matching('composting')]);
+
+    await el.handleSearch('compsting');
+
+    expect(el.activeLayout.renderEmpty).toHaveBeenCalledWith('compsting');
+    expect(el.activeLayout.renderError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -166,3 +166,80 @@ describe('discovery did-you-mean prompt', () => {
     expect(shadow.querySelector('.mp-search-discovery-input').value).toBe('composting');
   });
 });
+
+// A listbox is a set of options. The container only carries that role while it
+// holds result cards — the prompt, the zero-results message with its button, and
+// the failure alert are prose and controls, which assistive tech may skip or
+// mis-announce as malformed options inside a listbox.
+describe('discovery listbox role', () => {
+  const roleOf = (shadow) =>
+    shadow.getElementById('mp-search-discovery-results').getAttribute('role');
+
+  it('carries the listbox role while results are on screen', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith(null), { found: 1 });
+    expect(roleOf(shadow)).toBe('listbox');
+  });
+
+  it('drops it for the empty state, so the suggestion button is not a listbox child', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith(null), { found: 1 });
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    expect(roleOf(shadow)).toBeNull();
+    expect(shadow.querySelector('.mp-search-discovery-suggest')).not.toBeNull();
+  });
+
+  it('drops it for the initial and failure surfaces too', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith(null), { found: 1 });
+    layout.renderError('composting');
+    expect(roleOf(shadow)).toBeNull();
+
+    layout.renderResults(modelWith(null), { found: 1 });
+    layout.renderInitial();
+    expect(roleOf(shadow)).toBeNull();
+  });
+
+  it('restores it once results render again', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderEmpty('compsting');
+    layout.renderResults(modelWith(null), { found: 1 });
+    expect(roleOf(shadow)).toBe('listbox');
+  });
+});
+
+describe('discovery did-you-mean label contract', () => {
+  function mountWithLabel(label) {
+    const ctx = makeCtx();
+    ctx.t = (k) => (k === 'didYouMeanLabel' ? label : k);
+    const layout = createDiscoveryLayout(ctx);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    mountedHosts.push(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    shadow.innerHTML = layout.buildMarkup();
+    layout.cacheElements(shadow);
+    return { layout, shadow };
+  }
+
+  it('substitutes {q} in a translated label', () => {
+    const { layout, shadow } = mountWithLabel('Meintest du {q}?');
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    expect(shadow.querySelector('.mp-search-discovery-suggest').textContent)
+      .toBe('Meintest du composting?');
+  });
+
+  it('renders a label containing markup as text, never as markup', () => {
+    const { layout, shadow } = mountWithLabel('<img src=x onerror=alert(1)> {q}?');
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    const button = shadow.querySelector('.mp-search-discovery-suggest');
+    expect(button.querySelector('img')).toBeNull();
+    expect(button.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import createDiscoveryLayout from '../layouts/discovery.js';
 
 // Hosts mounted during a test, torn down afterwards so DOM fixtures never leak
@@ -23,21 +23,25 @@ function makeCtx() {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;'),
-    t: (k) => k
+    // Echoing the key is enough for most assertions. didYouMeanLabel carries a
+    // {q} placeholder the layout has to substitute, so it needs a real template.
+    t: (k) => (k === 'didYouMeanLabel' ? 'Did you mean {q}?' : k),
+    search: vi.fn()
   };
 }
 
 // Mount the layout into a real shadow root (so getElementById works the same as
 // in the live widget) and return the layout plus its cached preview element.
 function mountDiscovery() {
-  const layout = createDiscoveryLayout(makeCtx());
+  const ctx = makeCtx();
+  const layout = createDiscoveryLayout(ctx);
   const host = document.createElement('div');
   document.body.appendChild(host);
   mountedHosts.push(host);
   const shadow = host.attachShadow({ mode: 'open' });
   shadow.innerHTML = layout.buildMarkup();
   layout.cacheElements(shadow);
-  return { layout, shadow };
+  return { layout, shadow, ctx };
 }
 
 function modelWith(featureImage) {
@@ -117,5 +121,48 @@ describe('discovery preview hero', () => {
     const img = preview.querySelector('img.mp-search-discovery-hero');
     expect(img).not.toBeNull();
     expect(img.getAttribute('src')).toBe('https://cdn.example.com/p.jpg');
+  });
+});
+
+describe('discovery did-you-mean prompt', () => {
+  it('adds the correction under the no-results message, keeping both on screen', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    const empty = shadow.querySelector('.mp-search-discovery-empty');
+    expect(empty.textContent).toContain('noResultsMessage');
+    const button = empty.querySelector('.mp-search-discovery-suggest');
+    expect(button.dataset.search).toBe('composting');
+    expect(button.textContent).toBe('Did you mean composting?');
+  });
+
+  it('escapes a suggested term rather than letting it into the markup', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderEmpty('x');
+    layout.renderDidYouMean('"><img src=x onerror=alert(1)>');
+
+    const empty = shadow.querySelector('.mp-search-discovery-empty');
+    expect(empty.querySelector('img')).toBeNull();
+  });
+
+  it('adds nothing when the surface is not the empty state (a failed request)', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderError('compsting');
+    layout.renderDidYouMean('composting');
+
+    expect(shadow.querySelector('.mp-search-discovery-suggest')).toBeNull();
+  });
+
+  it('runs the corrected term and puts it in the input when clicked', () => {
+    const { layout, shadow, ctx } = mountDiscovery();
+    layout.bindEvents();
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    shadow.querySelector('.mp-search-discovery-suggest').click();
+
+    expect(ctx.search).toHaveBeenCalledWith('composting');
+    expect(shadow.querySelector('.mp-search-discovery-input').value).toBe('composting');
   });
 });

--- a/packages/search-ui/src/__tests__/helpers.test.js
+++ b/packages/search-ui/src/__tests__/helpers.test.js
@@ -125,3 +125,75 @@ describe('facet filter composition', () => {
     expect(el.composeFilterBy(undefined)).toBe('authors:=[`Jannis`]');
   });
 });
+
+// The correction offered for a mistyped query is derived from the tokens the
+// typo-tolerant retry actually matched in the index, so the suggestion is always
+// a word the publisher has written — never a guess from a client-side dictionary.
+describe('didYouMeanFromHits', () => {
+  const el = makeInstance();
+
+  const hitMatching = (...tokens) => ({
+    document: { id: 'p1' },
+    highlight: { title: { matched_tokens: tokens, snippet: '' } }
+  });
+
+  it('replaces a mistyped word with the token the index actually holds', () => {
+    expect(el.didYouMeanFromHits('compsting', [hitMatching('composting')])).toBe('composting');
+  });
+
+  it('corrects only the mistyped word in a longer query', () => {
+    const hits = [hitMatching('composting', 'guide')];
+    expect(el.didYouMeanFromHits('compsting guide', hits)).toBe('composting guide');
+  });
+
+  it('returns null when every word is already in the index, so nothing is offered', () => {
+    // The words were right; the query missed for some other reason (an active
+    // filter, say). "Did you mean <exactly what you typed>?" helps nobody.
+    expect(el.didYouMeanFromHits('composting guide', [hitMatching('composting', 'guide')])).toBeNull();
+  });
+
+  it('returns null when the retry reported no matched tokens', () => {
+    expect(el.didYouMeanFromHits('compsting', [{ document: { id: 'p1' } }])).toBeNull();
+  });
+
+  it('leaves a word under four characters alone (Typesense would not correct it either)', () => {
+    // min_len_1typo defaults to 4: a three-letter word gets no typo budget on
+    // the server, so proposing a correction for one would be the client
+    // inventing a match the index never made.
+    expect(el.didYouMeanFromHits('teh', [hitMatching('the')])).toBeNull();
+  });
+
+  it('allows one typo for a medium word and two for a long one', () => {
+    expect(el.didYouMeanFromHits('gost', [hitMatching('ghost')])).toBe('ghost');
+    expect(el.didYouMeanFromHits('typsense', [hitMatching('typesense')])).toBe('typesense');
+  });
+
+  it('rejects a candidate beyond the typo budget rather than suggesting a stretch', () => {
+    expect(el.didYouMeanFromHits('gardening', [hitMatching('composting')])).toBeNull();
+  });
+
+  it('prefers the nearest candidate when several are within budget', () => {
+    expect(el.didYouMeanFromHits('gardeng', [hitMatching('gardens', 'gardening')])).toBe('gardens');
+  });
+
+  it('reads tokens from nested highlight shapes (array fields such as tags.name)', () => {
+    const hit = {
+      document: { id: 'p1' },
+      highlight: { tags: [{ name: { matched_tokens: ['composting'] } }] }
+    };
+    expect(el.didYouMeanFromHits('compsting', [hit])).toBe('composting');
+  });
+
+  it('reads tokens from the older `highlights` array shape', () => {
+    const hit = {
+      document: { id: 'p1' },
+      highlights: [{ field: 'title', matched_tokens: ['composting'] }]
+    };
+    expect(el.didYouMeanFromHits('compsting', [hit])).toBe('composting');
+  });
+
+  it('matches case-insensitively but offers the index spelling', () => {
+    expect(el.didYouMeanFromHits('Compsting', [hitMatching('Composting')])).toBe('Composting');
+    expect(el.didYouMeanFromHits('composting', [hitMatching('Composting')])).toBeNull();
+  });
+});

--- a/packages/search-ui/src/__tests__/palette.test.js
+++ b/packages/search-ui/src/__tests__/palette.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import createPaletteLayout from '../layouts/palette.js';
 
 // Hosts mounted during a test, torn down afterwards so DOM fixtures never leak
@@ -28,19 +28,23 @@ function makeCtx() {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;'),
-    t: (k) => k
+    // Echoing the key is enough for most assertions. didYouMeanLabel carries a
+    // {q} placeholder the layout has to substitute, so it needs a real template.
+    t: (k) => (k === 'didYouMeanLabel' ? 'Did you mean {q}?' : k),
+    search: vi.fn()
   };
 }
 
 function mountPalette() {
-  const layout = createPaletteLayout(makeCtx());
+  const ctx = makeCtx();
+  const layout = createPaletteLayout(ctx);
   const host = document.createElement('div');
   document.body.appendChild(host);
   mountedHosts.push(host);
   const shadow = host.attachShadow({ mode: 'open' });
   shadow.innerHTML = layout.buildMarkup();
   layout.cacheElements(shadow);
-  return { layout, shadow };
+  return { layout, shadow, ctx };
 }
 
 describe('palette request-failure state', () => {
@@ -84,5 +88,47 @@ describe('palette request-failure state', () => {
     const results = shadow.getElementById('mp-search-palette-listbox');
     expect(results.textContent).toContain('paletteNoResultsTitle');
     expect(results.querySelector('[role="alert"]')).toBeNull();
+  });
+});
+
+describe('palette did-you-mean prompt', () => {
+  it('offers the correction as a row below the no-results message', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    expect(results.textContent).toContain('paletteNoResultsTitle');
+    const row = results.querySelector('.mp-search-palette-row-suggest');
+    expect(row.textContent).toContain('Did you mean composting?');
+  });
+
+  it('accepts the correction on Enter, so the keyboard path never dead-ends', () => {
+    const { layout, shadow, ctx } = mountPalette();
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    expect(layout.handleKeydown({ key: 'Enter', preventDefault() {} })).toBe(true);
+    expect(ctx.search).toHaveBeenCalledWith('composting');
+    expect(shadow.querySelector('.mp-search-palette-input').value).toBe('composting');
+  });
+
+  it('escapes a suggested term rather than letting it into the markup', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderEmpty('x');
+    layout.renderDidYouMean('"><img src=x onerror=alert(1)>');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    expect(results.querySelector('img')).toBeNull();
+  });
+
+  it('drops the correction when the next query matches nothing either', () => {
+    const { layout, shadow } = mountPalette();
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+    layout.renderEmpty('mulching techniques');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    expect(results.querySelector('.mp-search-palette-row-suggest')).toBeNull();
   });
 });

--- a/packages/search-ui/src/__tests__/palette.test.js
+++ b/packages/search-ui/src/__tests__/palette.test.js
@@ -132,3 +132,41 @@ describe('palette did-you-mean prompt', () => {
     expect(results.querySelector('.mp-search-palette-row-suggest')).toBeNull();
   });
 });
+
+// The label is a translation from the site's config, so its text is escaped and
+// only the wrapper around the suggested term is markup — matching the modal and
+// discovery layouts, which previously differed on this.
+describe('palette did-you-mean label contract', () => {
+  function mountWithLabel(label) {
+    const ctx = makeCtx();
+    ctx.t = (k) => (k === 'didYouMeanLabel' ? label : k);
+    const layout = createPaletteLayout(ctx);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    mountedHosts.push(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    shadow.innerHTML = layout.buildMarkup();
+    layout.cacheElements(shadow);
+    return { layout, shadow };
+  }
+
+  it('substitutes {q} in a translated label', () => {
+    const { layout, shadow } = mountWithLabel('Meintest du {q}?');
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    const row = shadow.querySelector('.mp-search-palette-row-suggest');
+    expect(row.textContent).toContain('Meintest du composting?');
+    expect(row.querySelector('.mp-search-palette-suggest-term').textContent).toBe('composting');
+  });
+
+  it('renders a label containing markup as text, never as markup', () => {
+    const { layout, shadow } = mountWithLabel('<img src=x onerror=alert(1)> {q}?');
+    layout.renderEmpty('compsting');
+    layout.renderDidYouMean('composting');
+
+    const results = shadow.getElementById('mp-search-palette-listbox');
+    expect(results.querySelector('img')).toBeNull();
+    expect(results.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/packages/search-ui/src/__tests__/setup.js
+++ b/packages/search-ui/src/__tests__/setup.js
@@ -10,3 +10,23 @@ globalThis.BUNDLED_CSS = '';
 // only when a global config (or a search hash/param) is present. Tests
 // construct their own elements with explicit config, so leave this unset.
 delete globalThis.__MP_SEARCH_CONFIG__;
+
+// jsdom implements neither of these, and both are reached by ordinary widget
+// code: matchMedia backs the system-theme detection wired up in
+// initEventListeners, and scrollIntoView keeps the active row visible in the
+// palette. Neither has anything to observe in a headless DOM, so a no-op stub
+// is the accurate stand-in.
+if (typeof window.matchMedia !== 'function') {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {}
+  });
+}
+
+if (typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = function scrollIntoView() {};
+}

--- a/packages/search-ui/src/layouts/discovery.css
+++ b/packages/search-ui/src/layouts/discovery.css
@@ -542,14 +542,46 @@
 .mp-search-discovery-empty,
 .mp-search-discovery-preview-empty {
   display: flex;
+  /* Column, so the zero-results message can be joined by the "did you mean"
+     prompt underneath it rather than beside it. */
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: calc(0.875 * var(--mp-rem));
   height: 100%;
   min-height: calc(6 * var(--mp-rem));
   padding: calc(2 * var(--mp-rem));
   text-align: center;
   color: var(--color-text-secondary);
   font-size: calc(0.9375 * var(--mp-rem));
+}
+
+/* "Did you mean …" — the one route forward out of the empty state. */
+.mp-search-discovery-suggest {
+  font: inherit;
+  font-size: calc(0.9375 * var(--mp-rem));
+  color: var(--color-text);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 9999px;
+  padding: calc(0.4375 * var(--mp-rem)) calc(1 * var(--mp-rem));
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.mp-search-discovery-suggest:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--accent-color);
+}
+
+.mp-search-discovery-suggest:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.mp-search-discovery-suggest strong {
+  color: var(--accent-color);
+  font-weight: 600;
 }
 
 /* Initial state (before any query) and the notice state (a failed request):

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -63,13 +63,29 @@ export default function createDiscoveryLayout(ctx) {
       + `<span aria-hidden="true">🔒</span> ${esc(ctx.t('membersLabel'))}</span>`;
   }
 
-  // The spelling-correction prompt offered under the empty message. The term
-  // comes from the index (see the core's didYouMeanFromHits), so it is escaped
-  // before it reaches the markup.
+  // The spelling-correction prompt offered under the empty message. Both halves
+  // are text: the term comes from the index (see the core's didYouMeanFromHits)
+  // and the label from the site's translations, so each is escaped and only the
+  // wrapper around the term is markup.
   function didYouMeanHtml(term) {
     const safe = esc(term);
-    const label = esc(ctx.t('didYouMeanLabel')).replace('{q}', `<strong>${safe}</strong>`);
+    const label = ctx
+      .t('didYouMeanLabel')
+      .split('{q}')
+      .map((part) => esc(part))
+      .join(`<strong>${safe}</strong>`);
     return `<button type="button" class="${P}-discovery-suggest" data-search="${safe}">${label}</button>`;
+  }
+
+  // A listbox is a set of options, so the container only carries that role
+  // while it actually holds result cards. The other surfaces it renders —
+  // the initial prompt, the zero-results message with its "did you mean"
+  // button, the failure alert — are prose and controls, which assistive tech
+  // may skip or mis-announce as malformed options inside a listbox.
+  function setListboxRole(isListbox) {
+    if (!refs.results) return;
+    if (isListbox) refs.results.setAttribute('role', 'listbox');
+    else refs.results.removeAttribute('role');
   }
 
   // Panel display state. 'initial' (before any query) and 'notice' (a failed
@@ -445,6 +461,7 @@ export default function createDiscoveryLayout(ctx) {
       model = [];
       selectedIndex = -1;
       setPanelState('initial');
+      setListboxRole(false);
       if (refs.results) {
         refs.results.innerHTML =
           `<div class="${P}-discovery-prompt">`
@@ -473,6 +490,7 @@ export default function createDiscoveryLayout(ctx) {
       model = [];
       selectedIndex = -1;
       setPanelState(null);
+      setListboxRole(false);
       const q = (query || '').trim();
       if (refs.results) {
         refs.results.innerHTML = `<div class="${P}-discovery-empty">${esc(ctx.t('noResultsMessage'))}</div>`;
@@ -502,6 +520,7 @@ export default function createDiscoveryLayout(ctx) {
       model = [];
       selectedIndex = -1;
       setPanelState('notice');
+      setListboxRole(false);
       if (refs.results) {
         refs.results.innerHTML =
           `<div class="${P}-discovery-prompt" role="alert">`
@@ -523,6 +542,7 @@ export default function createDiscoveryLayout(ctx) {
     renderResults(nextModel, meta) {
       if (!refs.results) return;
       setPanelState(null);
+      setListboxRole(true);
 
       // Preserve the selected post (by id) across the re-render where possible;
       // otherwise default to the first hit.

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -63,6 +63,15 @@ export default function createDiscoveryLayout(ctx) {
       + `<span aria-hidden="true">🔒</span> ${esc(ctx.t('membersLabel'))}</span>`;
   }
 
+  // The spelling-correction prompt offered under the empty message. The term
+  // comes from the index (see the core's didYouMeanFromHits), so it is escaped
+  // before it reaches the markup.
+  function didYouMeanHtml(term) {
+    const safe = esc(term);
+    const label = esc(ctx.t('didYouMeanLabel')).replace('{q}', `<strong>${safe}</strong>`);
+    return `<button type="button" class="${P}-discovery-suggest" data-search="${safe}">${label}</button>`;
+  }
+
   // Panel display state. 'initial' (before any query) and 'notice' (a failed
   // request) both collapse the three-pane grid to a single centred column,
   // because neither has facets or a preview to show; null restores the grid.
@@ -346,6 +355,20 @@ export default function createDiscoveryLayout(ctx) {
           const idx = Number(card.dataset.index);
           if (!Number.isNaN(idx)) selectIndex(idx, { scroll: false });
         });
+
+        // "Did you mean …": run the corrected term as if it had been typed.
+        refs.results.addEventListener('click', (e) => {
+          const suggest = e.target.closest(`.${P}-discovery-suggest`);
+          if (!suggest) return;
+          e.preventDefault();
+          const term = suggest.dataset.search;
+          if (!term) return;
+          if (refs.input) {
+            refs.input.value = term;
+            refs.input.focus();
+          }
+          ctx.search(term);
+        });
       }
 
       // Preview "Read post" link analytics (capture, before navigation).
@@ -459,6 +482,17 @@ export default function createDiscoveryLayout(ctx) {
         refs.preview.innerHTML = `<div class="${P}-discovery-preview-empty">${esc(ctx.t('discoveryNoSelection'))}</div>`;
       }
       if (refs.count) refs.count.textContent = q ? `0 ${ctx.t('resultsLabel')}` : '';
+    },
+
+    // Offer a corrected term for a query that matched nothing as typed. Called
+    // by the core right after renderEmpty, so it adds to that message rather
+    // than replacing it — the empty state stands on its own if the retry finds
+    // nothing to suggest.
+    renderDidYouMean(term) {
+      if (!refs.results || !term) return;
+      const empty = refs.results.querySelector(`.${P}-discovery-empty`);
+      if (!empty) return;
+      empty.insertAdjacentHTML('beforeend', didYouMeanHtml(term));
     },
 
     // The request failed (timeout, offline, unreachable host). Distinct from

--- a/packages/search-ui/src/layouts/palette.css
+++ b/packages/search-ui/src/layouts/palette.css
@@ -365,6 +365,14 @@
   color: var(--color-text-secondary);
 }
 
+/* "Did you mean …" row. It reuses the shared row styling because it behaves
+   like the other refining rows (recent, tag, author) — only the suggested term
+   needs a colour of its own. */
+.mp-search-palette .mp-search-palette-suggest-term {
+  color: var(--accent-color);
+  font-weight: 600;
+}
+
 /* Footer command bar */
 .mp-search-palette .mp-search-palette-footer {
   display: flex;

--- a/packages/search-ui/src/layouts/palette.js
+++ b/packages/search-ui/src/layouts/palette.js
@@ -15,8 +15,8 @@
 // buildMarkup(), cacheElements(root), bindEvents(), onOpen(), onClose(),
 // focusInput(), setQuery(q), getQuery(), setTheme(isDark), renderInitial(),
 // renderLoading(), renderEmpty(query), renderError(query),
-// renderResults(model, meta), renderSuggestions(), renderFacets(counts,
-// selected), handleKeydown(e).
+// renderDidYouMean(term), renderResults(model, meta), renderSuggestions(),
+// renderFacets(counts, selected), handleKeydown(e).
 
 const RECENT_KEY = 'mp-search-palette-recent';
 const RECENT_MAX = 5;
@@ -44,6 +44,8 @@ export default function createPaletteLayout(ctx) {
   let currentModel = [];
   let currentFacetCounts = [];
   let currentQuery = '';
+  // Spelling correction offered for a query that matched nothing, or null.
+  let currentSuggestion = null;
 
   // Recent searches, loaded from localStorage and mirrored in memory.
   let recent = loadRecent();
@@ -176,13 +178,14 @@ export default function createPaletteLayout(ctx) {
   }
 
   // Activate the row at index. newTab opens posts in a new tab. Posts navigate
-  // (after a click-track + recent push); recent/tag/author rows refine the
-  // query by typing their value back into the input.
+  // (after a click-track + recent push); recent/tag/author/suggest rows refine
+  // the query by typing their value back into the input.
   function activate(index, newTab) {
     const item = flatItems[index];
     if (!item) return;
 
-    if (item.kind === 'recent' || item.kind === 'tag' || item.kind === 'author') {
+    if (item.kind === 'recent' || item.kind === 'tag' || item.kind === 'author' ||
+        item.kind === 'suggest') {
       // Ignore malformed rows so we never type the literal "undefined" into the
       // input or issue a query for it.
       const value = item.value;
@@ -287,6 +290,29 @@ export default function createPaletteLayout(ctx) {
       </div>`;
   }
 
+  // The spelling-correction prompt, built as a navigable row so Enter picks it
+  // up like any other refining row — the reader never has to reach for the
+  // mouse to accept a correction.
+  function suggestRowHtml() {
+    if (!currentSuggestion) return '';
+
+    flatItems.push({ kind: 'suggest', value: currentSuggestion });
+    const idx = flatItems.length - 1;
+    const label = ctx
+      .t('didYouMeanLabel')
+      .replace('{q}', `<strong class="${L}-suggest-term">${ctx.escapeHtmlAttr(currentSuggestion)}</strong>`);
+
+    return `
+      <div class="${L}-group" role="group">
+        <div class="${L}-row ${L}-row-suggest" id="${L}-row-${idx}"
+             role="option" aria-selected="false" data-index="${idx}">
+          <span class="${L}-row-icon" aria-hidden="true">↳</span>
+          <span class="${L}-row-title">${label}</span>
+          <span class="${L}-row-enter" aria-hidden="true">↵</span>
+        </div>
+      </div>`;
+  }
+
   // In-surface keyboard navigation. Returns true when the key was consumed so
   // the core (which owns Esc and Cmd/Ctrl+K) can tell whether to act on it.
   function handleKeydownImpl(e) {
@@ -339,7 +365,7 @@ export default function createPaletteLayout(ctx) {
         <div class="${L}-empty">
           <p class="${L}-empty-title">${ctx.t('paletteNoResultsTitle').replace('{q}', ctx.escapeHtmlAttr(currentQuery))}</p>
           <p class="${L}-empty-sub">${ctx.t('paletteNoResultsSub')}</p>
-        </div>`;
+        </div>${suggestRowHtml()}`;
       activeIndex = 0;
       applyActive();
       setStatus(pluralResults(0));
@@ -526,6 +552,7 @@ export default function createPaletteLayout(ctx) {
       currentQuery = '';
       currentModel = [];
       currentFacetCounts = [];
+      currentSuggestion = null;
       flatItems = [];
       activeIndex = 0;
     },
@@ -556,6 +583,7 @@ export default function createPaletteLayout(ctx) {
     renderInitial() {
       currentModel = [];
       currentFacetCounts = [];
+      currentSuggestion = null;
       activeIndex = 0;
       setStatus('');
       if (refs.results) refs.results.innerHTML = recentSurfaceHtml();
@@ -568,7 +596,17 @@ export default function createPaletteLayout(ctx) {
 
     renderEmpty(query) {
       currentModel = [];
+      currentSuggestion = null;
       currentQuery = query || currentQuery;
+      renderSurface();
+    },
+
+    // Offer a corrected term for a query that matched nothing as typed. Called
+    // by the core right after renderEmpty, so the empty surface is repainted
+    // with the prompt as its one actionable row.
+    renderDidYouMean(term) {
+      if (!term) return;
+      currentSuggestion = term;
       renderSurface();
     },
 
@@ -579,6 +617,7 @@ export default function createPaletteLayout(ctx) {
     renderError(query) {
       currentModel = [];
       currentFacetCounts = [];
+      currentSuggestion = null;
       currentQuery = query || currentQuery;
       flatItems = [];
       activeIndex = 0;
@@ -595,6 +634,7 @@ export default function createPaletteLayout(ctx) {
 
     renderResults(model, meta) {
       currentModel = Array.isArray(model) ? model : [];
+      currentSuggestion = null;
       if (meta) {
         if (typeof meta.query === 'string') currentQuery = meta.query;
         if (Array.isArray(meta.facetCounts)) currentFacetCounts = meta.facetCounts;

--- a/packages/search-ui/src/layouts/palette.js
+++ b/packages/search-ui/src/layouts/palette.js
@@ -298,9 +298,13 @@ export default function createPaletteLayout(ctx) {
 
     flatItems.push({ kind: 'suggest', value: currentSuggestion });
     const idx = flatItems.length - 1;
+    // Label text and term are both escaped; only the wrapper is markup (the
+    // same contract the modal and discovery layouts use).
     const label = ctx
       .t('didYouMeanLabel')
-      .replace('{q}', `<strong class="${L}-suggest-term">${ctx.escapeHtmlAttr(currentSuggestion)}</strong>`);
+      .split('{q}')
+      .map((part) => ctx.escapeHtmlAttr(part))
+      .join(`<strong class="${L}-suggest-term">${ctx.escapeHtmlAttr(currentSuggestion)}</strong>`);
 
     return `
       <div class="${L}-group" role="group">

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -130,6 +130,83 @@ import Typesense from 'typesense';
     // `connectionTimeoutSeconds`.
     const DEFAULT_CONNECTION_TIMEOUT_SECONDS = 5;
 
+    // Spelling correction ("did you mean"). The retry that produces it asks for
+    // two typos per word — Typesense's own maximum — because the first, strict
+    // request already established that nothing matches as typed.
+    const DID_YOU_MEAN_NUM_TYPOS = 2;
+    // How much of the retry to mine for the correction. The top hits are the
+    // most relevant ones, and the prompt offers a single term.
+    const DID_YOU_MEAN_HIT_SAMPLE = 3;
+    const DID_YOU_MEAN_TOKEN_SAMPLE = 24;
+
+    // Whether a query already tolerated typos. Typesense's own default is 2, so
+    // an absent value is lenient; the widget's defaults set it to 0 explicitly.
+    // The value may also be the per-field CSV form ("2,1"), lenient when any
+    // field allows a typo.
+    function alreadyTypoTolerant(numTypos) {
+        if (numTypos === undefined || numTypos === null || numTypos === '') return true;
+        return String(numTypos)
+            .split(',')
+            .some(value => Number(value.trim()) > 0);
+    }
+
+    // The typo budget Typesense's defaults allow for a word this long
+    // (min_len_1typo: 4, min_len_2typo: 7). Applying the server's own rule
+    // keeps a suggestion to words it could actually have corrected.
+    function typoBudget(word) {
+        if (word.length >= 7) return 2;
+        if (word.length >= 4) return 1;
+        return 0;
+    }
+
+    // Levenshtein distance between two words, abandoned as soon as it is known
+    // to exceed `max` (returning max + 1). Only used to decide which indexed
+    // token a mistyped word most likely meant, so the exact value past the
+    // budget carries no information.
+    function editDistanceWithin(a, b, max) {
+        if (Math.abs(a.length - b.length) > max) return max + 1;
+
+        let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+        for (let i = 1; i <= a.length; i++) {
+            const current = [i];
+            let rowMin = i;
+            for (let j = 1; j <= b.length; j++) {
+                const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+                current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + cost);
+                if (current[j] < rowMin) rowMin = current[j];
+            }
+            if (rowMin > max) return max + 1;
+            previous = current;
+        }
+        return previous[b.length];
+    }
+
+    // Every token Typesense reports as matched on a hit. The highlight payload
+    // is read structurally rather than field by field, because its shape varies
+    // with the Typesense version (`highlight` object vs. the older `highlights`
+    // array) and nested fields (tags.name) nest their token lists further.
+    function matchedTokensFrom(hit) {
+        const tokens = [];
+
+        const collect = (value) => {
+            if (Array.isArray(value)) value.forEach(collect);
+            else if (typeof value === 'string' && value) tokens.push(value);
+        };
+
+        const walk = (node) => {
+            if (!node || typeof node !== 'object') return;
+            if (Array.isArray(node)) { node.forEach(walk); return; }
+            if (node.matched_tokens !== undefined) collect(node.matched_tokens);
+            Object.values(node).forEach(value => {
+                if (value && typeof value === 'object') walk(value);
+            });
+        };
+
+        walk(hit && hit.highlight);
+        walk(hit && hit.highlights);
+        return tokens;
+    }
+
     // Web Component Definition
     class MagicPagesSearchElement extends HTMLElement {
         constructor() {
@@ -143,6 +220,12 @@ import Typesense from 'typesense';
             this.scrollPosition = 0;
             this.selectedIndex = -1;
             this.searchDebounceTimeout = null;
+
+            // Monotonic id of the newest query. The did-you-mean retry resolves
+            // after a second request, so it checks this before rendering — a
+            // suggestion for a query the reader has already typed past must
+            // never land on top of newer results.
+            this.searchSequence = 0;
             this.cachedElements = {};
             this.typesenseClient = null;
 
@@ -170,6 +253,9 @@ import Typesense from 'typesense';
                 emptyStateMessage: 'Start typing to search...',
                 loadingMessage: 'Searching...',
                 noResultsMessage: 'No results found for your search',
+                // Spelling correction offered when a query matched nothing as
+                // typed. {q} is replaced with the suggested term.
+                didYouMeanLabel: 'Did you mean {q}?',
                 // Shown when the search request itself failed (timeout, offline,
                 // unreachable host) — never for a query that genuinely matched
                 // nothing.
@@ -701,6 +787,7 @@ import Typesense from 'typesense';
                                     <div class="${CSS_PREFIX}-empty-message">
                                         <p>${this.t('noResultsMessage')}</p>
                                     </div>
+                                    <div id="${CSS_PREFIX}-did-you-mean" class="${CSS_PREFIX}-did-you-mean ${CSS_PREFIX}-hidden"></div>
                                 </div>
                                 <div id="${CSS_PREFIX}-error" class="${CSS_PREFIX}-error ${CSS_PREFIX}-hidden" role="alert">
                                     <p class="${CSS_PREFIX}-error-title">${this.t('errorMessage')}</p>
@@ -727,6 +814,7 @@ import Typesense from 'typesense';
             this.loadingState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-loading`);
             this.emptyState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-empty`);
             this.errorState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-error`);
+            this.didYouMeanState = this.shadowRoot.querySelector(`#${CSS_PREFIX}-did-you-mean`);
         }
 
         getCommonSearchesHtml() {
@@ -863,6 +951,17 @@ import Typesense from 'typesense';
                 }, true);
             }
 
+            // "Did you mean …" prompt (delegated; the container is part of the
+            // empty state and persists across renders).
+            if (this.didYouMeanState) {
+                this.didYouMeanState.addEventListener('click', (e) => {
+                    const button = e.target.closest(`.${CSS_PREFIX}-did-you-mean-btn`);
+                    if (!button) return;
+                    e.preventDefault();
+                    this.applySearchTerm(button.dataset.search);
+                });
+            }
+
             // Common searches
             this.attachCommonSearchListeners();
 
@@ -918,21 +1017,26 @@ import Typesense from 'typesense';
                 if (!btn) return;
 
                 e.preventDefault();
-                const searchTerm = btn.dataset.search;
-
-                if (this.searchInput) {
-                    this.selectedIndex = -1;
-                    this.searchInput.value = searchTerm;
-                    this.searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-                    setTimeout(() => {
-                        this.searchInput.focus();
-                        this.searchInput.setSelectionRange(searchTerm.length, searchTerm.length);
-                    }, 0);
-                }
+                this.applySearchTerm(btn.dataset.search);
             };
 
             container.addEventListener('click', handleClick);
             container.addEventListener('touchend', handleClick);
+        }
+
+        // Put a term into the search box and run it, as if the reader had typed
+        // it. Shared by the suggestion chips and the "did you mean" prompt so
+        // both take the same debounced path and leave the caret at the end.
+        applySearchTerm(term) {
+            if (!term || !this.searchInput) return;
+
+            this.selectedIndex = -1;
+            this.searchInput.value = term;
+            this.searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+            setTimeout(() => {
+                this.searchInput.focus();
+                this.searchInput.setSelectionRange(term.length, term.length);
+            }, 0);
         }
 
         lockBodyScroll() {
@@ -1090,6 +1194,11 @@ import Typesense from 'typesense';
         async handleSearch(query) {
             query = query?.trim();
 
+            // Every call supersedes the one before it. The did-you-mean retry
+            // finishes after its own round trip, so it carries this token and
+            // renders only while it still describes what is on screen.
+            const sequence = ++this.searchSequence;
+
             if (!query) {
                 this.selectedIndex = -1;
                 if (this.activeLayout) {
@@ -1109,11 +1218,12 @@ import Typesense from 'typesense';
             // the normalized model + facet counts to the layout to render.
             if (this.activeLayout) {
                 this.activeLayout.renderLoading();
+                const searchParams = this.getSearchParameters();
                 try {
                     const results = await this.getTypesenseClient()
                         .collections(this.config.collectionName)
                         .documents()
-                        .search({ q: query, ...this.getSearchParameters() });
+                        .search({ q: query, ...searchParams });
 
                     const resultCount = typeof results.found === 'number' ? results.found : results.hits.length;
                     this.lastQuery = query;
@@ -1124,6 +1234,13 @@ import Typesense from 'typesense';
                     }
                     if (!results.hits.length) {
                         this.activeLayout.renderEmpty(query);
+                        const suggestion = await this.fetchDidYouMean(query, searchParams);
+                        // Additive: a layout chunk older than this feature keeps
+                        // its plain empty surface rather than breaking.
+                        if (suggestion && sequence === this.searchSequence &&
+                            typeof this.activeLayout.renderDidYouMean === 'function') {
+                            this.activeLayout.renderDidYouMean(suggestion);
+                        }
                         return;
                     }
                     const model = results.hits.map((hit, i) => this.normalizeHit(hit, i));
@@ -1183,10 +1300,18 @@ import Typesense from 'typesense';
                 }
 
                 if (results.hits.length === 0) {
+                    // Cleared first, so a suggestion for an earlier query can
+                    // never sit under this one while the retry is in flight.
+                    this.renderDidYouMean(null);
                     if (this.emptyState) this.emptyState.classList.remove(`${CSS_PREFIX}-hidden`);
                     if (this.hitsList) {
                         this.hitsList.innerHTML = '';
                         this.hitsList.classList.add(`${CSS_PREFIX}-hidden`);
+                    }
+
+                    const suggestion = await this.fetchDidYouMean(query, searchParams);
+                    if (suggestion && sequence === this.searchSequence) {
+                        this.renderDidYouMean(suggestion);
                     }
                     return;
                 }
@@ -1265,6 +1390,123 @@ import Typesense from 'typesense';
                 }
                 if (this.facetsContainer) this.facetsContainer.classList.add(`${CSS_PREFIX}-hidden`);
             }
+        }
+
+        // A query that matched nothing, re-run once with typo tolerance raised,
+        // so a misspelling can be offered back to the reader as a correction
+        // instead of a dead end. Returns the corrected phrase, or null when
+        // there is nothing worth offering.
+        async fetchDidYouMean(query, searchParams) {
+            // On unless the host turned it off: the widget matches strictly
+            // (num_typos: 0), so without this a mistyped word is a dead end.
+            if (this.config.enableDidYouMean === false) return null;
+
+            // A host that already searches leniently took its best shot on the
+            // first request; repeating it more leniently would find the same
+            // nothing. So strict-matching hosts (the default) pay one extra
+            // request, and only on a genuine miss; lenient ones pay none.
+            if (alreadyTypoTolerant(searchParams.num_typos)) return null;
+
+            let results;
+            try {
+                results = await this.getTypesenseClient()
+                    .collections(this.config.collectionName)
+                    .documents()
+                    .search({
+                        ...searchParams,
+                        q: query,
+                        // The defaults switch typo tolerance off both ways, so
+                        // the retry has to lift both.
+                        typo_tolerance: true,
+                        num_typos: DID_YOU_MEAN_NUM_TYPOS
+                    });
+            } catch (error) {
+                // The correction is an extra on top of an empty result the
+                // reader is already looking at. A failed retry leaves that
+                // empty state alone rather than escalating to an error the
+                // first request never hit.
+                this.logSearchError(error);
+                return null;
+            }
+
+            const hits = Array.isArray(results?.hits) ? results.hits : [];
+            if (!hits.length) return null;
+
+            return this.didYouMeanFromHits(query, hits);
+        }
+
+        // The phrase to offer for `query`, derived from what the typo-tolerant
+        // retry actually matched in the index — so the wording comes from the
+        // publisher's own posts rather than a client-side dictionary. Each typed
+        // word is either confirmed by a matched token or replaced by the nearest
+        // one within the typo budget Typesense allows for a word that length.
+        // Returns null when nothing changed: there is nothing to suggest to a
+        // reader who already typed the words the index holds.
+        didYouMeanFromHits(query, hits) {
+            const candidates = [];
+            const indexed = new Set();
+
+            for (const hit of hits.slice(0, DID_YOU_MEAN_HIT_SAMPLE)) {
+                for (const token of matchedTokensFrom(hit)) {
+                    const lower = token.toLowerCase();
+                    if (indexed.has(lower)) continue;
+                    indexed.add(lower);
+                    candidates.push(token);
+                    if (candidates.length >= DID_YOU_MEAN_TOKEN_SAMPLE) break;
+                }
+                if (candidates.length >= DID_YOU_MEAN_TOKEN_SAMPLE) break;
+            }
+
+            if (candidates.length === 0) return null;
+
+            let corrected = false;
+            const words = query.split(/\s+/).filter(Boolean).map(word => {
+                // The index holds this word as typed — whatever went wrong with
+                // the query, it was not this one.
+                if (indexed.has(word.toLowerCase())) return word;
+
+                const budget = typoBudget(word);
+                if (budget === 0) return word;
+
+                let best = null;
+                let bestDistance = budget + 1;
+                for (const candidate of candidates) {
+                    const distance = editDistanceWithin(word.toLowerCase(), candidate.toLowerCase(), budget);
+                    if (distance < bestDistance) {
+                        best = candidate;
+                        bestDistance = distance;
+                        // A distance of 0 is impossible here (the word is not in
+                        // the index), so 1 is as close as a candidate can get.
+                        if (distance === 1) break;
+                    }
+                }
+
+                if (!best) return word;
+                corrected = true;
+                return best;
+            });
+
+            return corrected ? words.join(' ') : null;
+        }
+
+        // The "did you mean" prompt inside the modal's empty state. Passing null
+        // clears it.
+        renderDidYouMean(term) {
+            if (!this.didYouMeanState) return;
+
+            if (!term) {
+                this.didYouMeanState.innerHTML = '';
+                this.didYouMeanState.classList.add(`${CSS_PREFIX}-hidden`);
+                return;
+            }
+
+            const safeTerm = this.escapeHtmlAttr(term);
+            const label = this.escapeHtmlAttr(this.t('didYouMeanLabel'))
+                .replace('{q}', `<strong class="${CSS_PREFIX}-did-you-mean-term">${safeTerm}</strong>`);
+
+            this.didYouMeanState.innerHTML =
+                `<button type="button" class="${CSS_PREFIX}-did-you-mean-btn" data-search="${safeTerm}">${label}</button>`;
+            this.didYouMeanState.classList.remove(`${CSS_PREFIX}-hidden`);
         }
 
         getSearchParameters() {

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -1225,6 +1225,11 @@ import Typesense from 'typesense';
                         .documents()
                         .search({ q: query, ...searchParams });
 
+                    // A superseded query's results were never on screen, so they
+                    // must not repaint over the newer query's — nor be reported
+                    // to analytics or take over click attribution.
+                    if (sequence !== this.searchSequence) return;
+
                     const resultCount = typeof results.found === 'number' ? results.found : results.hits.length;
                     this.lastQuery = query;
                     this.trackSearch(query, resultCount);
@@ -1246,7 +1251,11 @@ import Typesense from 'typesense';
                     const model = results.hits.map((hit, i) => this.normalizeHit(hit, i));
                     this.activeLayout.renderResults(model, { query, found: resultCount, facetCounts: results.facet_counts });
                 } catch (error) {
+                    // Logged even when superseded — a failing connection is
+                    // worth a console trace whether or not its query is still
+                    // the current one.
                     this.logSearchError(error);
+                    if (sequence !== this.searchSequence) return;
                     // A failed request is not an empty archive. Layout chunks
                     // are fetched separately from the core, so fall back to the
                     // empty surface for a layout that predates renderError.
@@ -1278,6 +1287,10 @@ import Typesense from 'typesense';
                     .documents()
                     .search(searchParameters);
 
+                // Superseded while in flight: the newer query owns the surface,
+                // and its own request is still running — so leave the loading
+                // state alone rather than reporting this one's outcome.
+                if (sequence !== this.searchSequence) return;
 
                 if (this.loadingState) this.loadingState.classList.add(`${CSS_PREFIX}-hidden`);
 
@@ -1378,7 +1391,9 @@ import Typesense from 'typesense';
                 this.hitsList.classList.toggle(`${CSS_PREFIX}-grid`, this.config.template === 'grid');
                 this.hitsList.classList.remove(`${CSS_PREFIX}-hidden`);
             } catch (error) {
+                // Logged even when superseded (see the layout path above).
                 this.logSearchError(error);
+                if (sequence !== this.searchSequence) return;
                 // The request failed, so show the error state — not the empty
                 // state, which would tell the reader the archive has nothing on
                 // their topic. The empty state was hidden before the request.
@@ -1501,8 +1516,15 @@ import Typesense from 'typesense';
             }
 
             const safeTerm = this.escapeHtmlAttr(term);
-            const label = this.escapeHtmlAttr(this.t('didYouMeanLabel'))
-                .replace('{q}', `<strong class="${CSS_PREFIX}-did-you-mean-term">${safeTerm}</strong>`);
+            // The translation is publisher config, not markup: its own text is
+            // escaped and only the wrapper around the term is HTML. Splitting on
+            // the placeholder — rather than escaping the whole string and then
+            // substituting into it — keeps that contract obvious, and is the
+            // same in all three layouts.
+            const label = this.t('didYouMeanLabel')
+                .split('{q}')
+                .map(part => this.escapeHtmlAttr(part))
+                .join(`<strong class="${CSS_PREFIX}-did-you-mean-term">${safeTerm}</strong>`);
 
             this.didYouMeanState.innerHTML =
                 `<button type="button" class="${CSS_PREFIX}-did-you-mean-btn" data-search="${safeTerm}">${label}</button>`;

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -704,6 +704,41 @@
     font-size: calc(0.875 * var(--mp-rem));
 }
 
+/* "Did you mean …" prompt. Sits under the empty state's message, because that
+   is the moment it matters: the reader is looking at zero results and this is
+   the one route forward. */
+.mp-search-did-you-mean {
+    margin-top: calc(1 * var(--mp-rem));
+}
+
+.mp-search-did-you-mean-btn {
+    font: inherit;
+    font-size: calc(0.9375 * var(--mp-rem));
+    color: var(--color-text);
+    background: var(--color-surface-elevated);
+    border: 1px solid var(--color-border);
+    border-radius: 9999px;
+    padding: calc(0.4375 * var(--mp-rem)) calc(1 * var(--mp-rem));
+    cursor: pointer;
+    box-shadow: var(--shadow-sm);
+    transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.mp-search-did-you-mean-btn:hover {
+    background: var(--color-surface-hover);
+    border-color: var(--accent-color);
+}
+
+.mp-search-did-you-mean-btn:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+.mp-search-did-you-mean-term {
+    color: var(--accent-color);
+    font-weight: 600;
+}
+
 /* Close button */
 .mp-search-close {
     position: fixed;


### PR DESCRIPTION
Closes #68.

`enableDidYouMean` was accepted into the config and stored, but nothing read it. Since the widget searches strictly (`num_typos: 0`), a reader who mistypes a word gets "No results found" and no way forward — and the option that reads as the answer to that did nothing.

## What changes

A zero-hit query is re-run once with `num_typos: 2`. If the retry finds posts, the reader is offered the corrected term:

- **modal** and **discovery**: a pill button under the no-results message
- **palette**: a navigable row, so `↵` accepts the correction

Picking it runs the corrected search.

The suggested wording comes from the retry's `matched_tokens`, so it is always a word the publisher's own posts contain rather than a guess from a dictionary that doesn't know the archive. A typed word is only replaced within the typo budget Typesense itself allows for a word that length (nothing under four characters, one typo up to six, two beyond), and a query whose words are all in the index is left alone instead of being offered back unchanged.

## Cost and failure behaviour

- The retry is skipped when the host already sets a non-zero `num_typos` — their first request was the lenient one. Strict-matching sites pay one extra request, and only on a genuine miss; lenient ones pay none.
- A failed retry leaves the ordinary empty state alone rather than escalating to an error the first request never hit.
- A suggestion whose query the reader has already typed past is dropped, never rendered over newer results.
- Layout chunks are fetched separately from the core, so a chunk that predates `renderDidYouMean` keeps its plain empty surface.

Strict matching stays the default ranking behaviour. Hosts opt out with `enableDidYouMean: false`; the prompt is translatable through the new `didYouMeanLabel` key.

## Tests

32 new tests (105 total in the package, all passing): the correction derivation (budgets, nested/legacy highlight shapes, case handling, nothing-to-correct), the request behaviour (one extra request, skip paths, retry failure, stale-suggestion guard, escaping), and the prompt in all three layouts including palette's `↵` path.

Verified end-to-end in the playground against a real Typesense in all three layouts — mistyped query shows the prompt, accepting it returns the post.

The playground mock now honours `num_typos` and returns `matched_tokens`, so the feature is demonstrable without a Typesense server.

## Summary by Sourcery

Add archive-aware spelling correction for strict zero-result searches while keeping newer search results authoritative.

New Features:
- Offer archive-derived spelling corrections after strict searches return no results, with clickable prompts across modal, discovery, and palette layouts.
- Support keyboard acceptance of spelling suggestions in the palette layout and provide configurable, translatable prompt text.

Bug Fixes:
- Prevent superseded searches and stale spelling retries from overwriting newer results, errors, or analytics state.
- Keep failed spelling-correction retries from replacing the normal no-results state with an error.

Enhancements:
- Derive suggestions from Typesense matched tokens within its typo budgets and avoid unchanged or unsafe suggestions.
- Escape suggestion terms and translated labels to prevent injected markup.
- Preserve compatibility with layout chunks that do not implement spelling-correction rendering.

Documentation:
- Document spelling correction, its configuration, translation key, retry behavior, and opt-out setting.

Tests:
- Add comprehensive coverage for correction derivation, retry behavior, stale-result guards, security escaping, translations, and all supported layouts.

Chores:
- Extend the playground search mock to support typo-tolerant matching and matched tokens for offline demonstrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Did you mean?” spelling suggestions when searches return no results.
  * Suggestions can be accepted by clicking or pressing Enter to rerun the corrected search.
  * Added configuration and translation support for enabling and customizing suggestions.
  * Added typo-tolerant matching while preserving strict search behavior by default.
* **Style**
  * Added responsive, accessible styling for suggestion prompts across search layouts.
* **Documentation**
  * Documented the new spelling-correction feature and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->