### PR TITLE
Show when a facet's value list was cut short

### DIFF
--- a/apps/playground/src/mock.js
+++ b/apps/playground/src/mock.js
@@ -193,6 +193,7 @@ export function mockSearchResponse(params = {}) {
   const q = (params.q || '').trim();
   // Arrives as a query-string value, so it is a string on the wire.
   const numTypos = Number(params.num_typos) || 0;
+  const maxFacetValues = Number(params.max_facet_values) || 0;
   const filters = parseFilterBy(params.filter_by);
   const facetBy = (params.facet_by || '').split(',').map((f) => f.trim()).filter(Boolean);
 
@@ -234,11 +235,16 @@ export function mockSearchResponse(params = {}) {
       const values = field === 'tags.name' ? post.tags : [].concat(post[field] || []);
       for (const value of values) counts[value] = (counts[value] || 0) + 1;
     }
+    const ordered = Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([value, count]) => ({ value, count, highlighted: value }));
+
     return {
       field_name: field,
-      counts: Object.entries(counts)
-        .sort((a, b) => b[1] - a[1])
-        .map(([value, count]) => ({ value, count, highlighted: value }))
+      // Honour the widget's cap the way Typesense does — values are ordered by
+      // count descending and the tail is dropped — so the playground shows the
+      // real truncation behaviour rather than an always-complete list.
+      counts: maxFacetValues > 0 ? ordered.slice(0, maxFacetValues) : ordered
     };
   });
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -367,14 +367,21 @@ window.__MP_SEARCH_CONFIG__ = {
 |-----|------|----------|-------------|
 | `field` | `String` | Yes | A faceted collection field (e.g. `tags.name`, `authors`) |
 | `label` | `String` | No | Heading shown above the field's chips (defaults to the field name) |
-| `limit` | `Number` | No | Maximum number of values shown for the field (defaults to 10) |
+| `limit` | `Number` | No | How many values the field shows before "Show more" (defaults to 10) |
 
 Behaviour:
 
 - When a query is active, each configured field renders as a row of selectable chips with a live result count. Chips are `<button>` elements with `aria-pressed`, so they are keyboard-focusable and toggle with Enter/Space.
 - Selecting one or more values filters the results and refreshes the counts. Values within a field are OR-ed; different fields are AND-ed together.
-- Selections can be cleared individually (toggling a chip off) or all at once via the **Clear filters** button.
+- Selections can be cleared individually (toggling a chip off) or all at once via the **Clear filters** button. A selected value stays on screen even when it ranks below the display limit, so the chip that switched a filter on is always the one that switches it off.
+- When a field has more values than its `limit`, a **Show more** control appears beneath its chips and **Show less** collapses it again. Without it, a value that exists on the current results but ranks below the cap simply vanishes, which reads as "this topic doesn't exist" rather than "this list is abridged".
 - A publisher-provided `typesenseSearchParams.filter_by` is **preserved**: facet selections are AND-ed with it rather than overwriting it.
+
+**How truncation is detected.** Each search asks Typesense for one more value than the longest facet list will show (`max_facet_values`), and that extra value is never rendered — its presence is what distinguishes a cut list from a complete one, without the cost of asking for a total. Expanding a field raises its cap by 40 and re-runs the current query, so the wider list costs one request and only when a reader asks for it. Both controls are translatable (`facetShowMoreLabel`, `facetShowLessLabel`).
+
+Typesense's `max_facet_values` is a single global parameter, so it is sized by the largest facet. A field with a smaller `limit` therefore receives more values than it shows — which is exactly what lets it detect its own truncation from the same response.
+
+The **palette** layout is unaffected: its Tags and Authors groups are query shortcuts capped at six rows by the layout itself, not the configurable filter rail.
 
 ## Members-only results
 
@@ -571,6 +578,8 @@ window.__MP_SEARCH_CONFIG__ = {
 | `ariaModalLabel` | "Search" | ARIA label for modal |
 | `ariaFacetsLabel` | "Filters" | ARIA label for the facet filter group |
 | `clearFiltersLabel` | "Clear filters" | Label for the button that clears active facet filters |
+| `facetShowMoreLabel` | "Show more" | Control shown under a facet whose value list was cut short |
+| `facetShowLessLabel` | "Show less" | Collapses an expanded facet back to its configured limit |
 | `membersLabel` | "Members only" | Badge text on gated (members-only / paid) results |
 | `ariaMembersLabel` | "Members-only content" | ARIA label for the members-only badge |
 | `untitledPost` | "Untitled" | Fallback for posts without titles |

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -982,3 +982,151 @@ describe('did-you-mean label contract', () => {
     expect(el.didYouMeanState.textContent).toContain('<img src=x onerror=alert(1)>');
   });
 });
+
+// Typesense returns facet values by count descending, so a cap always drops the
+// least common ones. A value that exists on the current results but falls
+// outside it used to be simply absent — indistinguishable, to a reader, from a
+// topic the archive does not cover.
+describe('facet truncation', () => {
+  const facetConfig = (limit) => ({
+    facets: [{ field: 'tags.name', label: 'Topics', limit }]
+  });
+
+  const countsFor = (n) =>
+    Array.from({ length: n }, (_, i) => ({ value: `Tag ${i + 1}`, count: n - i }));
+
+  const render = (el, counts) => {
+    el.renderFacets([{ field_name: 'tags.name', counts }]);
+    return {
+      chips: [...el.facetsContainer.querySelectorAll('.mp-search-facet-chip')],
+      more: el.facetsContainer.querySelector('.mp-search-facet-more')
+    };
+  };
+
+  it('asks for one more value than it will show, so a cut list is detectable', () => {
+    const el = mountWithConfig(facetConfig(10));
+    expect(el.getSearchParameters().max_facet_values).toBe(11);
+  });
+
+  it('sizes the request by the largest facet, since the parameter is global', () => {
+    const el = mountWithConfig({
+      facets: [
+        { field: 'tags.name', label: 'Topics', limit: 5 },
+        { field: 'authors', label: 'Authors', limit: 12 }
+      ]
+    });
+    expect(el.getSearchParameters().max_facet_values).toBe(13);
+  });
+
+  it('shows only the configured limit, not everything the response carried', () => {
+    // The smaller facet receives the larger facet's allowance; its own limit is
+    // what governs the list a reader sees.
+    const el = mountWithConfig(facetConfig(3));
+    const { chips } = render(el, countsFor(11));
+
+    expect(chips).toHaveLength(3);
+    expect(chips.map(c => c.dataset.facetValue)).toEqual(['Tag 1', 'Tag 2', 'Tag 3']);
+  });
+
+  it('offers the rest when the response held more than the limit', () => {
+    const el = mountWithConfig(facetConfig(3));
+    const { more } = render(el, countsFor(4));
+
+    expect(more).not.toBeNull();
+    expect(more.textContent.trim()).toBe('Show more');
+    expect(more.getAttribute('aria-expanded')).toBe('false');
+    // The control points at the list it expands.
+    expect(el.facetsContainer.querySelector(`#${more.getAttribute('aria-controls')}`)).not.toBeNull();
+  });
+
+  it('stays silent when the whole list fits', () => {
+    const el = mountWithConfig(facetConfig(3));
+    const { chips, more } = render(el, countsFor(3));
+
+    expect(chips).toHaveLength(3);
+    expect(more).toBeNull();
+  });
+
+  it('raises the cap and re-runs the query when the reader asks for more', async () => {
+    const calls = [];
+    const el = mountWithConfig(facetConfig(3));
+    el.typesenseClient = {
+      collections: () => ({
+        documents: () => ({
+          search: async (params) => {
+            calls.push(params);
+            return { found: 0, hits: [], facet_counts: [] };
+          }
+        })
+      })
+    };
+    el.initEventListeners();
+    el.searchInput.value = 'ghost';
+    render(el, countsFor(4));
+
+    el.facetsContainer.querySelector('.mp-search-facet-more').click();
+    await Promise.resolve();
+
+    expect(el.expandedFacets['tags.name']).toBe(43);
+    expect(calls.at(-1).max_facet_values).toBe(44);
+  });
+
+  it('shows the wider list and a way back once expanded', () => {
+    const el = mountWithConfig(facetConfig(3));
+    el.expandFacet('tags.name');
+    const { chips, more } = render(el, countsFor(11));
+
+    expect(chips).toHaveLength(11);
+    expect(more.textContent.trim()).toBe('Show less');
+    expect(more.getAttribute('aria-expanded')).toBe('true');
+    expect(more.dataset.facetExpand).toBe('less');
+  });
+
+  it('keeps offering more while values remain beyond the raised cap', () => {
+    const el = mountWithConfig(facetConfig(3));
+    el.expandFacet('tags.name');
+    const { more } = render(el, countsFor(60));
+
+    expect(more.textContent.trim()).toBe('Show more');
+    el.expandFacet('tags.name');
+    expect(el.expandedFacets['tags.name']).toBe(83);
+  });
+
+  it('collapses back to the publisher\'s limit', () => {
+    const el = mountWithConfig(facetConfig(3));
+    el.expandFacet('tags.name');
+    el.collapseFacet('tags.name');
+
+    expect(render(el, countsFor(11)).chips).toHaveLength(3);
+    expect(el.getSearchParameters().max_facet_values).toBe(4);
+  });
+
+  it('keeps a selected value visible even when it ranks below the cap', () => {
+    // Otherwise the only way out of that filter is Clear filters — the chip
+    // that switched it on would have vanished.
+    const el = mountWithConfig(facetConfig(3));
+    el.selectedFacets = { 'tags.name': new Set(['Tag 9']) };
+    const { chips } = render(el, countsFor(11));
+
+    const values = chips.map(c => c.dataset.facetValue);
+    expect(values).toContain('Tag 9');
+    expect(values.slice(0, 3)).toEqual(['Tag 1', 'Tag 2', 'Tag 3']);
+    expect([...chips].find(c => c.dataset.facetValue === 'Tag 9').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('falls back to the default limit for a missing or nonsensical one', () => {
+    for (const limit of [undefined, 0, -4, 'ten', NaN]) {
+      const el = mountWithConfig(facetConfig(limit));
+      expect(render(el, countsFor(20)).chips).toHaveLength(10);
+    }
+  });
+
+  it('collapses expanded facets when the modal closes', () => {
+    const el = mountWithConfig(facetConfig(3));
+    el.expandFacet('tags.name');
+    el.isModalOpen = true;
+    el.closeModal();
+
+    expect(el.expandedFacets).toEqual({});
+  });
+});

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1101,7 +1101,7 @@ describe('facet truncation', () => {
     expect(el.getSearchParameters().max_facet_values).toBe(4);
   });
 
-  it('keeps a selected value visible even when it ranks below the cap', () => {
+  it('keeps a selected value the response ranked below the cap', () => {
     // Otherwise the only way out of that filter is Clear filters — the chip
     // that switched it on would have vanished.
     const el = mountWithConfig(facetConfig(3));
@@ -1112,6 +1112,48 @@ describe('facet truncation', () => {
     expect(values).toContain('Tag 9');
     expect(values.slice(0, 3)).toEqual(['Tag 1', 'Tag 2', 'Tag 3']);
     expect([...chips].find(c => c.dataset.facetValue === 'Tag 9').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('keeps a selected value the response left out altogether', () => {
+    // The request asks for one value past the cap, not for everything, so a
+    // selected value ranked below that is simply not in the response. It still
+    // has to be on screen, with a zero count, or it cannot be switched off.
+    const el = mountWithConfig(facetConfig(3));
+    el.selectedFacets = { 'tags.name': new Set(['Tag 9']) };
+    const { chips } = render(el, countsFor(4));
+
+    const tag9 = chips.find(c => c.dataset.facetValue === 'Tag 9');
+    expect(tag9).toBeDefined();
+    expect(tag9.getAttribute('aria-pressed')).toBe('true');
+    expect(tag9.querySelector('.mp-search-facet-chip-count').textContent).toBe('0');
+  });
+
+  it('renders a selected field whose counts came back empty', () => {
+    // A filter can narrow the results to nothing. Suppressing the group then
+    // takes away the chip that caused it — and, with it, the way back.
+    const el = mountWithConfig(facetConfig(3));
+    el.selectedFacets = { 'tags.name': new Set(['Tag 9']) };
+    const { chips, more } = render(el, []);
+
+    expect(chips.map(c => c.dataset.facetValue)).toEqual(['Tag 9']);
+    expect(more).toBeNull();
+    expect(el.facetsContainer.classList.contains('mp-search-hidden')).toBe(false);
+  });
+
+  it('keeps the clear-filters control reachable when the response carried no facets at all', () => {
+    const el = mountWithConfig(facetConfig(3));
+    el.selectedFacets = { 'tags.name': new Set(['Tag 9']) };
+
+    el.renderFacets([]);
+
+    expect(el.facetsContainer.classList.contains('mp-search-hidden')).toBe(false);
+    expect(el.facetsContainer.querySelector('.mp-search-facet-clear')).not.toBeNull();
+  });
+
+  it('still hides the rail when there are no counts and nothing selected', () => {
+    const el = mountWithConfig(facetConfig(3));
+    el.renderFacets([]);
+    expect(el.facetsContainer.classList.contains('mp-search-hidden')).toBe(true);
   });
 
   it('falls back to the default limit for a missing or nonsensical one', () => {

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -243,3 +243,104 @@ describe('discovery did-you-mean label contract', () => {
     expect(button.textContent).toContain('<img src=x onerror=alert(1)>');
   });
 });
+
+// The rail rendered every value the response carried, so a facet's configured
+// limit never reached it and a cut list looked like a complete one. The core
+// owns the cap and reports the truncation; the rail renders both.
+describe('discovery facet truncation', () => {
+  const countsFor = (n) =>
+    Array.from({ length: n }, (_, i) => ({ value: `Tag ${i + 1}`, count: n - i }));
+
+  const facetCounts = (counts) => [{ field_name: 'tags.name', counts }];
+
+  // Stands in for the core's facet bookkeeping: a display cap of `limit`, and
+  // the truncation flags it derives from the response.
+  function mountWithCap(limit, { expanded = false } = {}) {
+    const ctx = makeCtx();
+    ctx.getFacetRows = vi.fn((field, counts) => ({
+      rows: counts.slice(0, limit),
+      truncated: counts.length > limit,
+      expanded
+    }));
+    ctx.getSelectedFacets = () => ({});
+    ctx.toggleFacet = vi.fn();
+    ctx.expandFacet = vi.fn();
+    ctx.collapseFacet = vi.fn();
+    ctx.requery = vi.fn();
+    ctx.close = vi.fn();
+    ctx.trackClick = vi.fn();
+
+    const layout = createDiscoveryLayout(ctx);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    mountedHosts.push(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    shadow.innerHTML = layout.buildMarkup();
+    layout.cacheElements(shadow);
+    return { layout, shadow, ctx };
+  }
+
+  it('shows the capped list and says the rest exists', () => {
+    const { layout, shadow } = mountWithCap(3);
+    layout.renderFacets(facetCounts(countsFor(11)), {});
+
+    const chips = shadow.querySelectorAll('.mp-search-discovery-facet-chip');
+    expect(chips).toHaveLength(3);
+
+    const more = shadow.querySelector('.mp-search-discovery-facet-more');
+    expect(more.textContent).toContain('facetShowMoreLabel');
+    expect(more.getAttribute('aria-expanded')).toBe('false');
+    expect(shadow.getElementById(more.getAttribute('aria-controls'))).not.toBeNull();
+  });
+
+  it('stays silent when the whole list fits', () => {
+    const { layout, shadow } = mountWithCap(5);
+    layout.renderFacets(facetCounts(countsFor(4)), {});
+
+    expect(shadow.querySelectorAll('.mp-search-discovery-facet-chip')).toHaveLength(4);
+    expect(shadow.querySelector('.mp-search-discovery-facet-more')).toBeNull();
+  });
+
+  it('asks the core for a wider list and re-runs the query', () => {
+    const { layout, shadow, ctx } = mountWithCap(3);
+    layout.bindEvents();
+    layout.renderFacets(facetCounts(countsFor(11)), {});
+
+    shadow.querySelector('.mp-search-discovery-facet-more').click();
+
+    expect(ctx.expandFacet).toHaveBeenCalledWith('tags.name');
+    expect(ctx.requery).toHaveBeenCalled();
+  });
+
+  it('collapses again from the expanded state', () => {
+    const { layout, shadow, ctx } = mountWithCap(11, { expanded: true });
+    layout.bindEvents();
+    layout.renderFacets(facetCounts(countsFor(11)), {});
+
+    const more = shadow.querySelector('.mp-search-discovery-facet-more');
+    expect(more.textContent).toContain('facetShowLessLabel');
+    more.click();
+
+    expect(ctx.collapseFacet).toHaveBeenCalledWith('tags.name');
+    expect(ctx.expandFacet).not.toHaveBeenCalled();
+  });
+
+  it('keeps a selected value that ranks below the cap, so it can be cleared', () => {
+    const { layout, shadow } = mountWithCap(3);
+    layout.renderFacets(facetCounts(countsFor(11)), { 'tags.name': new Set(['Tag 9']) });
+
+    const values = [...shadow.querySelectorAll('.mp-search-discovery-facet-chip')]
+      .map((c) => c.dataset.facetValue);
+    expect(values).toContain('Tag 9');
+  });
+
+  it('renders every returned value against a core that predates the cap', () => {
+    // Layout chunks are fetched separately from the core, so a newer chunk can
+    // meet an older core; it then behaves as this layout did before.
+    const { layout, shadow } = mountDiscovery();
+    layout.renderFacets(facetCounts(countsFor(11)), {});
+
+    expect(shadow.querySelectorAll('.mp-search-discovery-facet-chip')).toHaveLength(11);
+    expect(shadow.querySelector('.mp-search-discovery-facet-more')).toBeNull();
+  });
+});

--- a/packages/search-ui/src/__tests__/setup.js
+++ b/packages/search-ui/src/__tests__/setup.js
@@ -11,11 +11,14 @@ globalThis.BUNDLED_CSS = '';
 // construct their own elements with explicit config, so leave this unset.
 delete globalThis.__MP_SEARCH_CONFIG__;
 
-// jsdom implements neither of these, and both are reached by ordinary widget
-// code: matchMedia backs the system-theme detection wired up in
-// initEventListeners, and scrollIntoView keeps the active row visible in the
-// palette. Neither has anything to observe in a headless DOM, so a no-op stub
-// is the accurate stand-in.
+// jsdom gaps reached by ordinary widget code: matchMedia backs the system-theme
+// detection wired up in initEventListeners, scrollIntoView keeps the active row
+// visible in the palette, and window.scrollTo restores the reader's scroll
+// position when the modal closes. jsdom defines that last one, but its
+// implementation raises "Not implemented" through the virtual console, so it is
+// replaced outright rather than guarded like the other two. None of the three
+// has anything to observe in a headless DOM, so a no-op stub is the accurate
+// stand-in.
 if (typeof window.matchMedia !== 'function') {
   window.matchMedia = () => ({
     matches: false,
@@ -30,3 +33,5 @@ if (typeof window.matchMedia !== 'function') {
 if (typeof Element.prototype.scrollIntoView !== 'function') {
   Element.prototype.scrollIntoView = function scrollIntoView() {};
 }
+
+window.scrollTo = () => {};

--- a/packages/search-ui/src/layouts/discovery.css
+++ b/packages/search-ui/src/layouts/discovery.css
@@ -330,6 +330,31 @@
   box-shadow: 0 0 0 2px var(--accent-color);
 }
 
+/* Truncation control, sitting under the group's chips in the rail. */
+.mp-search-discovery-facet-more {
+  /* Left-aligned with the chips above it: the group is a flex column, so a
+     stretched button would centre its label instead. */
+  align-self: flex-start;
+  text-align: left;
+  margin-top: calc(0.375 * var(--mp-rem));
+  background: transparent;
+  border: none;
+  color: var(--accent-color);
+  font-size: calc(0.8125 * var(--mp-rem));
+  cursor: pointer;
+  padding: calc(0.25 * var(--mp-rem)) 0;
+}
+
+.mp-search-discovery-facet-more:hover {
+  text-decoration: underline;
+}
+
+.mp-search-discovery-facet-more:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-color);
+  border-radius: calc(0.25 * var(--mp-rem));
+}
+
 .mp-search-discovery-facet-empty {
   color: var(--color-text-secondary);
   font-size: calc(0.8125 * var(--mp-rem));

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -240,10 +240,19 @@ export default function createDiscoveryLayout(ctx) {
       // narrowed the set to where it no longer appears can still be cleared).
       if (fcCounts.length === 0 && selectedSet.size === 0) continue;
 
+      // The core owns the display cap (a facet's configured `limit`, or the
+      // raised cap once the reader expands it) and reports whether the response
+      // held more values than that. An older core without those helpers renders
+      // every returned value, as this layout did before.
+      const capped = typeof ctx.getFacetRows === 'function'
+        ? ctx.getFacetRows(group.field, fcCounts)
+        : null;
+      const visible = capped ? capped.rows : fcCounts;
+
       // Merge selected values missing from the live counts.
       const seen = new Set();
       const rows = [];
-      for (const c of fcCounts) {
+      for (const c of visible) {
         seen.add(c.value);
         rows.push({ value: c.value, count: c.count });
       }
@@ -266,10 +275,23 @@ export default function createDiscoveryLayout(ctx) {
         })
         .join('');
 
+      // A cut list says so, and offers the rest — otherwise a topic that exists
+      // on the current results but ranks below the cap reads as one that does
+      // not exist at all.
+      const chipsId = `${P}-discovery-facet-chips-${groupsHtml.length}`;
+      const toggle = capped && (capped.truncated || capped.expanded)
+        ? `<button type="button" class="${P}-discovery-facet-more" `
+          + `data-facet-field="${esc(group.field)}" `
+          + `data-facet-expand="${capped.truncated ? 'more' : 'less'}" `
+          + `aria-controls="${chipsId}" aria-expanded="${capped.expanded ? 'true' : 'false'}">`
+          + `${esc(ctx.t(capped.truncated ? 'facetShowMoreLabel' : 'facetShowLessLabel'))}</button>`
+        : '';
+
       groupsHtml.push(
         `<div class="${P}-facet-group ${P}-discovery-facet-group">`
         + `<p class="${P}-discovery-facet-title">${esc(group.label)}</p>`
-        + `<div class="${P}-facet-chips" role="group" aria-label="${esc(group.label)}">${chips}</div>`
+        + `<div id="${chipsId}" class="${P}-facet-chips" role="group" aria-label="${esc(group.label)}">${chips}</div>`
+        + toggle
         + `</div>`
       );
     }
@@ -409,6 +431,19 @@ export default function createDiscoveryLayout(ctx) {
             ctx.requery();
             return;
           }
+          const more = e.target.closest(`.${P}-discovery-facet-more`);
+          if (more) {
+            e.preventDefault();
+            const field = more.dataset.facetField;
+            if (!field) return;
+            if (more.dataset.facetExpand === 'less') ctx.collapseFacet(field);
+            else ctx.expandFacet(field);
+            // The wider (or narrower) list comes from the response, so the core
+            // re-runs the active query for it.
+            ctx.requery();
+            return;
+          }
+
           const chip = e.target.closest(`.${P}-facet-chip`);
           if (!chip) return;
           e.preventDefault();

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -207,6 +207,13 @@ import Typesense from 'typesense';
         return tokens;
     }
 
+    // Facet display. A facet's `limit` is how many values it shows; one more
+    // than that is requested, so a list that was cut can be told apart from a
+    // complete one without asking Typesense for a total. "Show more" raises the
+    // cap by a step, which costs one request and only when a reader asks.
+    const DEFAULT_FACET_LIMIT = 10;
+    const FACET_EXPANSION_STEP = 40;
+
     // Web Component Definition
     class MagicPagesSearchElement extends HTMLElement {
         constructor() {
@@ -240,6 +247,11 @@ import Typesense from 'typesense';
             // closes. Only used when `facets` is configured.
             this.selectedFacets = {};
 
+            // Facets the reader expanded past their configured limit, keyed by
+            // field name to the raised cap. Also reset when the modal closes,
+            // so a new session starts from the publisher's own limits.
+            this.expandedFacets = {};
+
             // Suggestions fetched from `suggestionsUrl`, cached for the page
             // session. `suggestionsFetched` guards against re-fetching (and
             // re-failing) on every modal open.
@@ -270,6 +282,10 @@ import Typesense from 'typesense';
                 ariaModalLabel: 'Search',
                 ariaFacetsLabel: 'Filters',
                 clearFiltersLabel: 'Clear filters',
+                // Shown under a facet whose value list was cut short, and on the
+                // control that collapses it again.
+                facetShowMoreLabel: 'Show more',
+                facetShowLessLabel: 'Show less',
                 membersLabel: 'Members only',
                 ariaMembersLabel: 'Members-only content',
                 untitledPost: 'Untitled',
@@ -645,6 +661,15 @@ import Typesense from 'typesense';
                     if (set.has(value)) set.delete(value); else set.add(value);
                 },
                 clearFacets: () => { this.selectedFacets = {}; },
+                // Facet display caps, so a layout can render the same abridged
+                // list the core does and show the same "show more" affordance.
+                getFacetRows: (field, counts) => {
+                    const facet = (this.config.facets || []).find(f => f.field === field);
+                    if (!facet) return null;
+                    return this.facetRows(facet, Array.isArray(counts) ? counts : []);
+                },
+                expandFacet: (field) => this.expandFacet(field),
+                collapseFacet: (field) => this.collapseFacet(field),
                 setFacetFilter: () => {},
                 search: (q) => this.handleSearch(q),
                 requery: () => this.rerunQueryForFacets(),
@@ -1133,8 +1158,10 @@ import Typesense from 'typesense';
             // the first search is emitted even if it repeats a prior query.
             this.lastQuery = '';
             this.lastTrackedQuery = null;
-            // Clear any active facet filters so a new session starts unfiltered.
+            // Clear any active facet filters so a new session starts unfiltered,
+            // and collapse any expanded facet back to its configured limit.
             this.selectedFacets = {};
+            this.expandedFacets = {};
             this.handleSearch('');
 
             // Restore focus
@@ -1711,9 +1738,16 @@ import Typesense from 'typesense';
             if (this.config.facets?.length) {
                 mergedParams.facet_by = this.config.facets.map(f => f.field).join(',');
 
-                const maxValues = Math.max(...this.config.facets.map(f => f.limit || 10));
-                if (Number.isFinite(maxValues)) {
-                    mergedParams.max_facet_values = maxValues;
+                // One more than the longest list any facet will show. The extra
+                // value is never rendered; it is what tells a cut list apart
+                // from a complete one. `max_facet_values` is a single global
+                // parameter, so the largest cap wins — which is also why a facet
+                // with a smaller limit receives more values than it shows, and
+                // can detect its own truncation from the same response.
+                const caps = this.config.facets.map(f => this.facetCap(f));
+                const maxCap = Math.max(...caps);
+                if (Number.isFinite(maxCap)) {
+                    mergedParams.max_facet_values = maxCap + 1;
                 }
 
                 const composed = this.composeFilterBy(mergedParams.filter_by);
@@ -1725,6 +1759,60 @@ import Typesense from 'typesense';
             }
 
             return mergedParams;
+        }
+
+        // How many values a facet shows when collapsed: its configured `limit`,
+        // or the default. A non-numeric or non-positive limit falls back to the
+        // default rather than hiding the facet entirely.
+        facetLimit(facet) {
+            const limit = facet && facet.limit;
+            return Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_FACET_LIMIT;
+        }
+
+        // How many values it shows right now — the same, unless the reader has
+        // expanded it.
+        facetCap(facet) {
+            const limit = this.facetLimit(facet);
+            const raised = facet ? this.expandedFacets[facet.field] : undefined;
+            return Number.isFinite(raised) && raised > limit ? raised : limit;
+        }
+
+        // Raise a facet's cap by one step. The wider list comes from the next
+        // request, so the reader pays for it only by asking.
+        expandFacet(field) {
+            const facet = (this.config.facets || []).find(f => f.field === field);
+            if (!facet) return;
+            this.expandedFacets[field] = this.facetCap(facet) + FACET_EXPANSION_STEP;
+        }
+
+        // Back to the publisher's configured limit.
+        collapseFacet(field) {
+            delete this.expandedFacets[field];
+        }
+
+        // The values a facet renders, and whether the response held more than
+        // that. Selected values are always kept, even when they rank below the
+        // cap — a filter the reader turned on must stay switchable off.
+        facetRows(facet, counts) {
+            const cap = this.facetCap(facet);
+            const selected = this.selectedFacets[facet.field];
+            const visible = counts.slice(0, cap);
+
+            if (selected && selected.size) {
+                const shown = new Set(visible.map(c => c.value));
+                for (const entry of counts.slice(cap)) {
+                    if (selected.has(entry.value) && !shown.has(entry.value)) {
+                        visible.push(entry);
+                        shown.add(entry.value);
+                    }
+                }
+            }
+
+            return {
+                rows: visible,
+                truncated: counts.length > cap,
+                expanded: cap > this.facetLimit(facet)
+            };
         }
 
         // Build the `filter_by` clause for the currently selected facet values:
@@ -1778,12 +1866,13 @@ import Typesense from 'typesense';
                 countsByField[fc.field_name] = fc.counts || [];
             }
 
-            const groups = this.config.facets.map(facet => {
+            const groups = this.config.facets.map((facet, groupIndex) => {
                 const counts = countsByField[facet.field] || [];
                 if (counts.length === 0) return '';
 
+                const { rows, truncated, expanded } = this.facetRows(facet, counts);
                 const selected = this.selectedFacets[facet.field];
-                const chips = counts.map(({ value, count }) => {
+                const chips = rows.map(({ value, count }) => {
                     const isSelected = selected ? selected.has(value) : false;
                     const safeValue = this.escapeHtmlAttr(value);
                     return `
@@ -1798,10 +1887,26 @@ import Typesense from 'typesense';
                     `;
                 }).join('');
 
+                // A cut list says so, and offers the rest. Without this the
+                // missing values read as "this topic doesn't exist" rather than
+                // "this list is abridged".
+                const chipsId = `${CSS_PREFIX}-facet-chips-${groupIndex}`;
+                const toggle = truncated || expanded
+                    ? `<button type="button"
+                            class="${CSS_PREFIX}-facet-more"
+                            data-facet-field="${this.escapeHtmlAttr(facet.field)}"
+                            data-facet-expand="${truncated ? 'more' : 'less'}"
+                            aria-controls="${chipsId}"
+                            aria-expanded="${expanded ? 'true' : 'false'}">${
+                                truncated ? this.t('facetShowMoreLabel') : this.t('facetShowLessLabel')
+                            }</button>`
+                    : '';
+
                 return `
                     <div class="${CSS_PREFIX}-facet-group">
                         <div class="${CSS_PREFIX}-facet-group-label">${this.escapeHtmlAttr(facet.label || facet.field)}</div>
-                        <div class="${CSS_PREFIX}-facet-chips" role="list">${chips}</div>
+                        <div id="${chipsId}" class="${CSS_PREFIX}-facet-chips" role="list">${chips}</div>
+                        ${toggle}
                     </div>
                 `;
             }).join('');
@@ -1826,6 +1931,19 @@ import Typesense from 'typesense';
                 if (clearBtn) {
                     e.preventDefault();
                     this.selectedFacets = {};
+                    this.rerunQueryForFacets();
+                    return;
+                }
+
+                const moreBtn = e.target.closest(`.${CSS_PREFIX}-facet-more`);
+                if (moreBtn) {
+                    e.preventDefault();
+                    const field = moreBtn.dataset.facetField;
+                    if (!field) return;
+                    if (moreBtn.dataset.facetExpand === 'less') this.collapseFacet(field);
+                    else this.expandFacet(field);
+                    // The wider (or narrower) list comes from the response, so
+                    // the current query is re-run for it.
                     this.rerunQueryForFacets();
                     return;
                 }

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -1800,10 +1800,25 @@ import Typesense from 'typesense';
 
             if (selected && selected.size) {
                 const shown = new Set(visible.map(c => c.value));
+
+                // Ranked below the cap but still in the response: keep its real
+                // count.
                 for (const entry of counts.slice(cap)) {
                     if (selected.has(entry.value) && !shown.has(entry.value)) {
                         visible.push(entry);
                         shown.add(entry.value);
+                    }
+                }
+
+                // Ranked below what was even requested, so the response does not
+                // carry it at all — the field asks for one value past the cap,
+                // not for everything. Shown with a zero count, as the discovery
+                // rail already does, because a chip the reader switched on has
+                // to stay switchable off.
+                for (const value of selected) {
+                    if (!shown.has(value)) {
+                        visible.push({ value, count: 0 });
+                        shown.add(value);
                     }
                 }
             }
@@ -1854,7 +1869,14 @@ import Typesense from 'typesense';
         renderFacets(facetCounts) {
             if (!this.facetsContainer) return;
 
-            if (!this.config.facets?.length || !Array.isArray(facetCounts) || facetCounts.length === 0) {
+            // An active selection keeps the rail on screen even when the
+            // response carried no counts at all: hiding it would take the
+            // "clear filters" control with it, stranding the reader in a filter
+            // they can no longer see, let alone undo.
+            const hasSelection = Object.values(this.selectedFacets).some(s => s && s.size > 0);
+            const hasCounts = Array.isArray(facetCounts) && facetCounts.length > 0;
+
+            if (!this.config.facets?.length || (!hasCounts && !hasSelection)) {
                 this.facetsContainer.innerHTML = '';
                 this.facetsContainer.classList.add(`${CSS_PREFIX}-hidden`);
                 return;
@@ -1862,16 +1884,20 @@ import Typesense from 'typesense';
 
             // Map configured fields to their display labels and order.
             const countsByField = {};
-            for (const fc of facetCounts) {
+            for (const fc of (hasCounts ? facetCounts : [])) {
                 countsByField[fc.field_name] = fc.counts || [];
             }
 
             const groups = this.config.facets.map((facet, groupIndex) => {
                 const counts = countsByField[facet.field] || [];
-                if (counts.length === 0) return '';
+                const selected = this.selectedFacets[facet.field];
+                // A field with an active selection renders even when the
+                // response carried no counts for it — a query that its own
+                // filter narrowed to nothing would otherwise take the chip away
+                // along with the only way to undo it.
+                if (counts.length === 0 && !(selected && selected.size)) return '';
 
                 const { rows, truncated, expanded } = this.facetRows(facet, counts);
-                const selected = this.selectedFacets[facet.field];
                 const chips = rows.map(({ value, count }) => {
                     const isSelected = selected ? selected.has(value) : false;
                     const safeValue = this.escapeHtmlAttr(value);
@@ -1911,7 +1937,6 @@ import Typesense from 'typesense';
                 `;
             }).join('');
 
-            const hasSelection = Object.values(this.selectedFacets).some(s => s && s.size > 0);
             const clearButton = hasSelection
                 ? `<button type="button" class="${CSS_PREFIX}-facet-clear">${this.t('clearFiltersLabel')}</button>`
                 : '';

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -455,6 +455,30 @@
     opacity: 0.7;
 }
 
+/* Truncation control. Reads as a quieter sibling of the chips it follows —
+   its job is to admit the list is abridged, not to compete with the values. */
+.mp-search-facet-more {
+    align-self: flex-start;
+    background: transparent;
+    border: none;
+    color: var(--accent-color);
+    cursor: pointer;
+    font-size: calc(0.8125 * var(--mp-rem));
+    padding: calc(0.25 * var(--mp-rem)) 0;
+    transition: opacity var(--transition-base);
+}
+
+.mp-search-facet-more:hover {
+    opacity: 0.7;
+    text-decoration: underline;
+}
+
+.mp-search-facet-more:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+    border-radius: calc(0.25 * var(--mp-rem));
+}
+
 .mp-search-hits-list {
     margin-block-start: calc(0.5 * var(--mp-rem));
     margin-block-end: calc(0.5 * var(--mp-rem));


### PR DESCRIPTION
Closes #69.

The facet rail showed the top values per field with no sign that anything was left out. Typesense orders facet values by count descending, so the cap always drops the least common ones — a tag on two posts could never appear, even when those were the top two results for the query. That reads as "this topic doesn't exist" rather than "this list is abridged".

## What changes

Each search asks for one more value than the longest list will show. That extra value is never rendered; its presence is what distinguishes a cut list from a complete one, with no need for a total. Where it appears, the field gets a **Show more** control that raises its cap and re-runs the current query, and **Show less** collapses it again — so the wider list costs one request, and only when a reader asks for it.

Applies to the modal chips and the discovery rail. Both labels are translatable (`facetShowMoreLabel`, `facetShowLessLabel`).

## Two related gaps closed on the way

- **`limit` now does what it documents.** It was described as the number of values shown for a field, but only fed the global `max_facet_values`; the modal and rail then rendered every value the response carried, so a field with `limit: 5` showed as many values as the largest facet allowed. Because `max_facet_values` is a single global parameter sized by the largest facet, smaller fields still receive more values than they show — which is exactly what lets each one detect its own truncation from the same response.
- **A selected value stays on screen even when it ranks below the cap**, so the chip that switched a filter on is always the one that switches it off, instead of vanishing and leaving *Clear filters* as the only way out.

## Deliberately out of scope

The palette layout is untouched: its Tags and Authors groups are query shortcuts capped at six rows by the layout itself, not the configurable filter rail this issue is about.

## Tests

20 new tests (91 in the package, all passing): the request sizing (`limit + 1`, global sizing across facets), the display cap and its fallbacks for a missing or nonsensical limit, the control appearing only when values were dropped, expansion raising the cap and re-running the query, repeated expansion, collapse, selected values surviving the cap, reset on close, and the rail's behaviour against a core that predates the cap.

Verified end-to-end in the playground in both layouts: collapsed list requests 11 and shows the control, expanding requests 43 and reveals the rest, collapsing returns to 11. The playground mock now honours `max_facet_values` the way Typesense does, so this is demonstrable without a real server.

## Summary by Sourcery

Expose when facet value lists are truncated and let readers expand or collapse them while keeping active filters recoverable.

New Features:
- Add Show more and Show less controls for truncated facet value lists in the modal and discovery rail.

Bug Fixes:
- Keep selected facet values visible, including when they fall outside the returned counts or results contain no facet counts.
- Make facet limits govern the number of displayed values and provide sensible defaults for invalid limits.

Enhancements:
- Detect facet truncation through globally sized requests that fetch one value beyond the largest configured cap, with expanded facets re-querying at a larger cap.
- Add accessible, translatable facet expansion controls and reset expanded state when the modal closes.
- Preserve compatibility with older discovery cores that do not provide facet-cap metadata.

Documentation:
- Document facet truncation behavior, selected-value persistence, expansion controls, and their translation labels.

Tests:
- Add coverage for facet request sizing, display limits, expansion and collapse, selected values, empty responses, discovery rendering, and legacy-core compatibility.

Chores:
- Update the playground Typesense mock to honor max_facet_values and improve the test DOM stubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Facet lists now show a manageable number of values by default.
  * Added accessible “Show more” and “Show less” controls for expanding or collapsing facet values.
  * Selected values remain visible even when outside the initial display limit.
  * Expanded facets automatically refresh results with additional values.
  * Expansion state resets when the search modal closes.
* **Documentation**
  * Updated facet configuration, expansion behavior, and translation guidance.
* **Style**
  * Improved styling and keyboard-focus visibility for facet expansion controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->