### PR TITLE
Honour searchAuthors when the host sets its own query_by

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -201,6 +201,8 @@ window.__MP_SEARCH_CONFIG__ = {
 
 This is opt-in so existing sites' search behaviour is unchanged. For finer control you can instead add `authors` to `searchFields` with an explicit weight.
 
+It also holds when you set your own `typesenseSearchParams.query_by`: the `authors` field is added to that list rather than to the defaults it replaces, and `query_by_weights` is extended alongside it so the two stay the same length (Typesense rejects a search where they differ). If `authors` is already in your `query_by` or `searchFields`, nothing is added and your weight stands.
+
 ### Advanced Search Parameters
 
 Use `typesenseSearchParams` to override any of the default Typesense search parameters. Custom parameters are merged with the defaults, so you only need to specify what you want to change.

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -201,7 +201,7 @@ window.__MP_SEARCH_CONFIG__ = {
 
 This is opt-in so existing sites' search behaviour is unchanged. For finer control you can instead add `authors` to `searchFields` with an explicit weight.
 
-It also holds when you set your own `typesenseSearchParams.query_by`: the `authors` field is added to that list rather than to the defaults it replaces, and `query_by_weights` is extended alongside it so the two stay the same length (Typesense rejects a search where they differ). If `authors` is already in your `query_by` or `searchFields`, nothing is added and your weight stands.
+It also holds when you set your own `typesenseSearchParams.query_by`: the `authors` field is added to that list rather than to the defaults it replaces. If you set `query_by_weights` as well, it is extended alongside `query_by` so the two stay the same length — Typesense rejects a search where they differ. If you leave weights unset they stay unset, which is what has Typesense weight every field equally. And if `authors` is already in your `query_by` or `searchFields`, nothing is added and your own weight stands.
 
 ### Advanced Search Parameters
 

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1172,3 +1172,94 @@ describe('facet truncation', () => {
     expect(el.expandedFacets).toEqual({});
   });
 });
+
+// `searchAuthors` and `typesenseSearchParams.query_by` both decide what a query
+// searches. The option used to edit the defaults, which a host's query_by
+// replaces wholesale — so it did nothing for exactly the hosts who had tuned
+// their query, and said nothing about it.
+describe('searchAuthors', () => {
+  const fieldsOf = (params) => params.query_by.split(',');
+
+  it('searches author names on the default query', () => {
+    const params = mountWithConfig({ searchAuthors: true }).getSearchParameters();
+    expect(fieldsOf(params)).toContain('authors');
+  });
+
+  it('searches them alongside a host-supplied query_by', () => {
+    const params = mountWithConfig({
+      searchAuthors: true,
+      typesenseSearchParams: { query_by: 'title,plaintext,excerpt' }
+    }).getSearchParameters();
+
+    expect(fieldsOf(params)).toEqual(['title', 'plaintext', 'excerpt', 'authors']);
+  });
+
+  it('keeps query_by_weights the same length as query_by', () => {
+    // Typesense rejects the search outright when the two lists differ, so a
+    // field added without its weight is worse than no field at all.
+    const params = mountWithConfig({
+      searchAuthors: true,
+      typesenseSearchParams: { query_by: 'title,plaintext', query_by_weights: '5,2' }
+    }).getSearchParameters();
+
+    expect(params.query_by).toBe('title,plaintext,authors');
+    expect(params.query_by_weights).toBe('5,2,1');
+  });
+
+  it('leaves weights unset when the host set none, so fields stay equally weighted', () => {
+    const params = mountWithConfig({
+      searchAuthors: true,
+      typesenseSearchParams: { query_by: 'title,plaintext' }
+    }).getSearchParameters();
+
+    expect(params.query_by).toBe('title,plaintext,authors');
+    expect(params.query_by_weights).toBeUndefined();
+  });
+
+  it('weights the default query the same way it always did', () => {
+    const params = mountWithConfig({ searchAuthors: true }).getSearchParameters();
+    const weights = params.query_by_weights.split(',');
+
+    expect(weights).toHaveLength(fieldsOf(params).length);
+    expect(weights.at(-1)).toBe('1');
+  });
+
+  it('adds nothing when the host already searches authors', () => {
+    const params = mountWithConfig({
+      searchAuthors: true,
+      typesenseSearchParams: { query_by: 'title,authors', query_by_weights: '5,3' }
+    }).getSearchParameters();
+
+    expect(params.query_by).toBe('title,authors');
+    // Its weight is the publisher's, not the one this option would have used.
+    expect(params.query_by_weights).toBe('5,3');
+  });
+
+  it('adds nothing when a publisher put authors in searchFields themselves', () => {
+    const params = mountWithConfig({
+      searchAuthors: true,
+      searchFields: { title: { weight: 5 }, authors: { weight: 4 } }
+    }).getSearchParameters();
+
+    expect(fieldsOf(params)).toEqual(['title', 'authors']);
+    expect(params.query_by_weights).toBe('5,4');
+  });
+
+  it('stays off unless asked for, whether or not query_by is set', () => {
+    expect(fieldsOf(mountWithConfig().getSearchParameters())).not.toContain('authors');
+    expect(fieldsOf(mountWithConfig({
+      typesenseSearchParams: { query_by: 'title,plaintext' }
+    }).getSearchParameters())).not.toContain('authors');
+  });
+
+  it('composes with semantic search, keeping both lists aligned', () => {
+    const params = mountWithConfig({
+      searchAuthors: true,
+      semanticSearch: true,
+      typesenseSearchParams: { query_by: 'title', query_by_weights: '5' }
+    }).getSearchParameters();
+
+    expect(fieldsOf(params)).toEqual(['title', 'authors', 'embedding']);
+    expect(params.query_by_weights).toBe('5,1,1');
+  });
+});

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -1558,6 +1558,37 @@ import Typesense from 'typesense';
             this.didYouMeanState.classList.remove(`${CSS_PREFIX}-hidden`);
         }
 
+        // Add a field to what a query searches, keeping `query_by_weights` the
+        // same length as `query_by`. That pairing is not cosmetic: Typesense
+        // rejects a search outright when the two lists differ, so a field added
+        // without its weight would turn a ranking tweak into a failed request.
+        // Weights are left alone when unset — Typesense then weights every field
+        // equally, and a partial list would be worse than none. Returns whether
+        // the field was added, which is false when it was already searched.
+        addQueryField(params, field, weight = 1) {
+            if (!field) return false;
+
+            const fields = String(params.query_by || '')
+                .split(',')
+                .map(f => f.trim())
+                .filter(Boolean);
+            if (fields.includes(field)) return false;
+
+            fields.push(field);
+            params.query_by = fields.join(',');
+
+            if (params.query_by_weights) {
+                const weights = String(params.query_by_weights)
+                    .split(',')
+                    .map(w => w.trim())
+                    .filter(Boolean);
+                weights.push(String(weight));
+                params.query_by_weights = weights.join(',');
+            }
+
+            return true;
+        }
+
         getSearchParameters() {
             const fields = Object.keys(this.config.searchFields || {}).length > 0
                 ? this.config.searchFields
@@ -1580,16 +1611,6 @@ import Typesense from 'typesense';
                     highlightFields.push(field);
                 }
             });
-
-            // Opt-in: make author names matchable by keyword. Off by default
-            // (matching the historical behaviour where typing an author name
-            // found nothing); set config.searchAuthors = true to include the
-            // `authors` field in query_by at a low weight. Publishers can also
-            // add `authors` to searchFields directly for full control.
-            if (this.config.searchAuthors && !searchFields.includes('authors')) {
-                searchFields.push('authors');
-                weights.push(1);
-            }
 
             // Default search parameters
             const defaultParams = {
@@ -1622,6 +1643,18 @@ import Typesense from 'typesense';
                 ...defaultParams,
                 ...customParams
             };
+
+            // Opt-in: make author names matchable by keyword. Off by default
+            // (matching the historical behaviour where typing an author name
+            // found nothing). Applied to the merged params rather than the
+            // defaults, because a host-supplied `query_by` replaces the default
+            // one wholesale — appending to the defaults meant the option did
+            // nothing for exactly the hosts who had tuned their query. Publishers
+            // can still put `authors` in searchFields (or their own query_by) for
+            // full control over its weight; this is a no-op when it is there.
+            if (this.config.searchAuthors) {
+                this.addQueryField(mergedParams, 'authors');
+            }
 
             // Click analytics needs each hit's `id` in the response. A host
             // that overrides `include_fields` may legitimately omit it, so
@@ -1691,27 +1724,7 @@ import Typesense from 'typesense';
             // When disabled, queries stay purely lexical.
             if (this.config.semanticSearch) {
                 const embeddingField = this.config.embeddingFieldName || 'embedding';
-                const queryFields = String(mergedParams.query_by || '')
-                    .split(',')
-                    .map(f => f.trim())
-                    .filter(Boolean);
-                if (!queryFields.includes(embeddingField)) {
-                    queryFields.push(embeddingField);
-                    mergedParams.query_by = queryFields.join(',');
-
-                    // Typesense requires query_by_weights to have the same number
-                    // of entries as query_by when it is set, so add a weight for
-                    // the embedding field too. (When no weights are set, leaving
-                    // it unset is valid — Typesense weights fields equally.)
-                    if (mergedParams.query_by_weights) {
-                        const weights = String(mergedParams.query_by_weights)
-                            .split(',')
-                            .map(w => w.trim())
-                            .filter(Boolean);
-                        weights.push('1');
-                        mergedParams.query_by_weights = weights.join(',');
-                    }
-
+                if (this.addQueryField(mergedParams, embeddingField)) {
                     // Bias hybrid ranking toward keyword matches so a strong
                     // textual hit (e.g. an author name) outranks merely
                     // vector-near posts, and drop far semantic-only matches.


### PR DESCRIPTION
Closes #70.

`searchAuthors: true` did nothing whenever `typesenseSearchParams.query_by` was also set. The option appended `authors` while building the *default* params, and a host's `query_by` then replaced that default wholesale — so the documented way to make author names matchable failed silently for exactly the hosts who had tuned their query. Searching an author whose name appears in no title or body returned nothing, with no sign the option had been dropped.

## What changes

The field is unioned into the **merged** params, where a host's `query_by` is visible — the shape the semantic-search block already used for the embedding field.

Both now go through one helper, so the rule they share lives in one place: appending to `query_by` also extends `query_by_weights` when it is set. That pairing is not cosmetic — Typesense rejects a search whose two lists differ in length, so a field added without its weight would turn a ranking tweak into a failed request. Weights stay untouched when unset, since Typesense then weights fields equally and a partial list would be worse than none.

Nothing is added when `authors` is already searched, whether from the host's `query_by` or from `searchFields`, so a publisher's own weight for it still stands. The option remains off by default.

## Tests

9 new tests (82 in the package, all passing). Four of them fail against the old behaviour: authors alongside a host `query_by`, the weights staying aligned, weights staying absent when the host set none, and composition with semantic search. The rest are regression guards — the default path, the two no-op cases, and off-by-default with and without `query_by`.

## Verified against a real Typesense

Not just the mock: with `query_by: 'title,plaintext'` and `query_by_weights: '5,2'` the widget sends `title,plaintext,authors` / `5,2,1`, the server accepts it, and searching an author's name returns their posts.

## Summary by Sourcery

Preserve opt-in author matching across custom Typesense search configurations while maintaining valid field-weight settings.

Bug Fixes:
- Ensure the opt-in author search field is preserved when hosts provide custom Typesense query fields.
- Keep query field weights aligned when author or semantic-search fields are added, while preserving publisher-supplied author weights.

Enhancements:
- Centralize query-field additions so author and semantic search compose consistently without duplicating fields or creating incomplete weight lists.

Documentation:
- Document author search behavior with custom query fields and query weights.

Tests:
- Add coverage for custom query fields, weight alignment, duplicate author fields, default behavior, opt-in behavior, and semantic-search composition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable and collapsible facet lists with localized controls.
  * Facet lists now support configurable limits and preserve selected values beyond the visible range.
  * Facet updates automatically refresh search results.
  * Author searches now work correctly with custom search fields and weights, including semantic search compatibility.

* **Bug Fixes**
  * Prevented duplicate author fields and maintained alignment between fields and weights.
  * Preserved selected facets when filtered results have no counts.

* **Documentation**
  * Documented author-search behavior with custom search settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->