### PR TITLE
Stop treating typo_tolerance as a Typesense parameter

### DIFF
--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -214,8 +214,7 @@ Use `typesenseSearchParams` to override any of the default Typesense search para
 | `sort_by` | `'_text_match:desc,published_at:desc'` | Sort by text match relevance, then by publication date |
 | `prefix` | `true` | Enable prefix matching (matches partial words as you type) |
 | `per_page` | `20` | Number of results per page |
-| `typo_tolerance` | `false` | Whether to allow typo corrections in search |
-| `num_typos` | `0` | Maximum number of typos to tolerate per word |
+| `num_typos` | `0` | Typos tolerated per word — `0` matches strictly, `1`–`2` are typical (see [Typo tolerance](#typo-tolerance)) |
 | `prioritize_exact_match` | `true` | Prioritize results with exact phrase matches |
 | `drop_tokens_threshold` | `0` | Token drop threshold for relaxing multi-word queries |
 | `enable_nested_fields` | `true` | Enable searching in nested fields (e.g., `tags.name`) |
@@ -237,14 +236,15 @@ typesenseSearchParams: {
 }
 ```
 
-**Enabling typo tolerance:**
+**Typo tolerance:**
 
 ```javascript
 typesenseSearchParams: {
-    typo_tolerance: true,
     num_typos: 2  // Allow up to 2 typos per word
 }
 ```
+
+`num_typos` is the only control — there is no separate on/off switch. See [Typo tolerance](#typo-tolerance) below for why the widget defaults to `0`.
 
 **Filtering results:**
 
@@ -262,7 +262,6 @@ window.__MP_SEARCH_CONFIG__ = {
     typesenseSearchParams: {
         sort_by: 'published_at:desc',
         per_page: 10,
-        typo_tolerance: true,
         num_typos: 1,
         filter_by: 'tags.slug:!=internal'
     }
@@ -270,6 +269,22 @@ window.__MP_SEARCH_CONFIG__ = {
 ```
 
 > **Note:** If you provide a custom `query_by` without a matching `query_by_weights`, the default weights are automatically removed to avoid mismatches. If you override `query_by`, you should also provide `query_by_weights`.
+
+### Typo tolerance
+
+The widget searches with `num_typos: 0`, which is **stricter than Typesense's own default of `2`**. That is deliberate: a query returns the posts that contain the words, not their near-neighbours, which is what makes results predictable — and a reader who does mistype gets the ["Did you mean …?" prompt](#spelling-correction) instead of a wrong answer dressed up as a right one.
+
+Raise it if you would rather absorb typos in the results themselves:
+
+```javascript
+typesenseSearchParams: {
+    num_typos: 2   // or 1 for something in between
+}
+```
+
+Typesense's related knobs — `min_len_1typo`, `min_len_2typo`, `typo_tokens_threshold` — pass through the same way.
+
+> **`typo_tolerance` is not a Typesense parameter.** Earlier versions of this widget sent it and this page documented it as the switch for typo correction; it was neither. Typesense ignores unknown parameters, so a config that set `typo_tolerance: true` and stopped there kept matching strictly, silently. It is now read as an alias for `num_typos: 2` (an explicit `num_typos` wins) and logs a deprecation notice to the browser console. Set `num_typos` directly.
 
 ## Search suggestions
 

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1172,3 +1172,100 @@ describe('facet truncation', () => {
     expect(el.expandedFacets).toEqual({});
   });
 });
+
+// `typo_tolerance` is not a Typesense search parameter and never was. The widget
+// sent it and the README documented it as the switch for typo correction, so a
+// host who set it got nothing: Typesense ignores unknown parameters, `num_typos`
+// stayed 0, and no layer said a word about it.
+describe('typo_tolerance', () => {
+  // console.error, not warn: the shipped bundle strips console.warn, so that is
+  // the only channel a publisher would ever read this on.
+  let notice;
+  beforeEach(() => {
+    notice = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    notice.mockRestore();
+  });
+
+  it('is not sent to Typesense on a default query', () => {
+    expect(mountWithConfig().getSearchParameters()).not.toHaveProperty('typo_tolerance');
+  });
+
+  it('is not forwarded when a host sets it', () => {
+    const params = mountWithConfig({
+      typesenseSearchParams: { typo_tolerance: true }
+    }).getSearchParameters();
+
+    expect(params).not.toHaveProperty('typo_tolerance');
+  });
+
+  it('reads a host-set true as the typo tolerance its author meant', () => {
+    const params = mountWithConfig({
+      typesenseSearchParams: { typo_tolerance: true }
+    }).getSearchParameters();
+
+    expect(params.num_typos).toBe(2);
+  });
+
+  it('lets an explicit num_typos win over the alias', () => {
+    const params = mountWithConfig({
+      typesenseSearchParams: { typo_tolerance: true, num_typos: 1 }
+    }).getSearchParameters();
+
+    expect(params.num_typos).toBe(1);
+  });
+
+  it('leaves matching strict for a host-set false', () => {
+    const params = mountWithConfig({
+      typesenseSearchParams: { typo_tolerance: false }
+    }).getSearchParameters();
+
+    expect(params.num_typos).toBe(0);
+    expect(params).not.toHaveProperty('typo_tolerance');
+  });
+
+  it('says so in the console, once, rather than failing silently', () => {
+    const el = mountWithConfig({ typesenseSearchParams: { typo_tolerance: true } });
+
+    el.getSearchParameters();
+    el.getSearchParameters();
+
+    // getSearchParameters runs on every keystroke; the message has to be
+    // findable, not buried under copies of itself.
+    expect(notice).toHaveBeenCalledTimes(1);
+    expect(notice.mock.calls[0][0]).toContain('num_typos');
+  });
+
+  it('stays quiet for a config that never mentions it', () => {
+    mountWithConfig({ typesenseSearchParams: { num_typos: 2 } }).getSearchParameters();
+    expect(notice).not.toHaveBeenCalled();
+  });
+
+  it('keeps num_typos: 0 as the widget default — stricter than Typesense own 2', () => {
+    expect(mountWithConfig().getSearchParameters().num_typos).toBe(0);
+  });
+
+  it('does not send it on the did-you-mean retry either', async () => {
+    const calls = [];
+    const el = mountWithConfig();
+    el.typesenseClient = {
+      collections: () => ({
+        documents: () => ({
+          search: async (params) => {
+            calls.push(params);
+            return { found: 0, hits: [] };
+          }
+        })
+      })
+    };
+
+    await el.handleSearch('compsting');
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].num_typos).toBe(2);
+    for (const params of calls) {
+      expect(params).not.toHaveProperty('typo_tolerance');
+    }
+  });
+});

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -130,6 +130,10 @@ import Typesense from 'typesense';
     // `connectionTimeoutSeconds`.
     const DEFAULT_CONNECTION_TIMEOUT_SECONDS = 5;
 
+    // What the deprecated `typo_tolerance: true` alias maps to. Typesense's own
+    // default, which is what a host asking for "typo tolerance" is describing.
+    const DEFAULT_TYPO_TOLERANT_NUM_TYPOS = 2;
+
     // Spelling correction ("did you mean"). The retry that produces it asks for
     // two typos per word — Typesense's own maximum — because the first, strict
     // request already established that nothing matches as typed.
@@ -1209,6 +1213,21 @@ import Typesense from 'typesense';
             return this.typesenseClient;
         }
 
+        // Tell the site owner about a config problem, once per key.
+        // getSearchParameters runs on every keystroke, so an unconditional
+        // message would fill the console and bury what it is trying to say.
+        //
+        // console.error, not console.warn: the production bundle strips warn
+        // (see the terser `drop_console` list in rollup.config.js), so a warning
+        // here would exist in the source and nowhere a publisher could ever read
+        // it — which is the same silence this message exists to break.
+        logConfigIssueOnce(key, message) {
+            if (!this.reportedConfigIssues) this.reportedConfigIssues = new Set();
+            if (this.reportedConfigIssues.has(key)) return;
+            this.reportedConfigIssues.add(key);
+            console.error(message);
+        }
+
         // A search request that never completed — timeout, offline, unreachable
         // host. Logged so a failing connection is diagnosable from the reader's
         // console (typesense-js logs its own retry warnings; this identifies the
@@ -1457,9 +1476,6 @@ import Typesense from 'typesense';
                     .search({
                         ...searchParams,
                         q: query,
-                        // The defaults switch typo tolerance off both ways, so
-                        // the retry has to lift both.
-                        typo_tolerance: true,
                         num_typos: DID_YOU_MEAN_NUM_TYPOS
                     });
             } catch (error) {
@@ -1598,7 +1614,10 @@ import Typesense from 'typesense';
                 highlight_full_fields: highlightFields.join(','),
                 highlight_affix_num_tokens: 30,
                 include_fields: 'id,title,url,excerpt,plaintext,published_at,tags,authors,feature_image,visibility',
-                typo_tolerance: false,
+                // Stricter than Typesense's own default of 2: a query returns
+                // the posts that contain the words, not their near-neighbours,
+                // which keeps results predictable. `enableDidYouMean` covers the
+                // misspelling case by retrying once and offering the correction.
                 num_typos: 0,
                 prefix: true,
                 per_page: 20,
@@ -1622,6 +1641,26 @@ import Typesense from 'typesense';
                 ...defaultParams,
                 ...customParams
             };
+
+            // `typo_tolerance` is not a Typesense search parameter — it never
+            // was. The widget used to send it and the README documented it as
+            // the switch for typo correction, so a host who set it got nothing:
+            // Typesense ignores unknown parameters, `num_typos` stayed 0, and
+            // nothing anywhere said so. It is read here as the alias its authors
+            // meant it to be (and never forwarded), so those configs start
+            // behaving as intended. An explicit `num_typos` always wins.
+            if (Object.prototype.hasOwnProperty.call(customParams, 'typo_tolerance')) {
+                delete mergedParams.typo_tolerance;
+                if (customParams.typo_tolerance && customParams.num_typos === undefined) {
+                    mergedParams.num_typos = DEFAULT_TYPO_TOLERANT_NUM_TYPOS;
+                }
+                this.logConfigIssueOnce(
+                    'typo_tolerance',
+                    'MagicPagesSearch: `typo_tolerance` is not a Typesense search parameter and does '
+                    + 'nothing on its own. Reading it as `num_typos: 2` for now; set `num_typos` '
+                    + 'directly instead (0 matches strictly, 1–2 tolerate typos).'
+                );
+            }
 
             // Click analytics needs each hit's `id` in the response. A host
             // that overrides `include_fields` may legitimately omit it, so


### PR DESCRIPTION
Closes #71.

`typo_tolerance` is not a Typesense search parameter and never has been. The widget sent it in its defaults and the README documented it as the switch for typo correction, with examples pairing it with `num_typos` as though one enabled the other. Typesense ignores unknown parameters, so a host who read the table, set `typo_tolerance: true` and stopped there kept matching strictly — no console message, no server error, just a search that quietly refused to forgive a typo.

**Confirmed against a live Typesense before changing anything:**

```
q=tomatos&num_typos=0&typo_tolerance=true  → found: 0
q=tomatos&num_typos=2                      → found: 1
```

## What changes

- Dropped from the default params, and from the did-you-mean retry, which had been lifting a flag that did nothing.
- A host-supplied `typo_tolerance` is read as the alias its author meant: `true` maps to `num_typos: 2` when `num_typos` was not set explicitly, so those configs start behaving as intended rather than changing from one no-op to another. It is never forwarded to the server, and an explicit `num_typos` always wins.
- A deprecation notice goes to the console, once per key (`getSearchParameters` runs on every keystroke).
- README: `num_typos` documented as the sole control, the invented parameter removed from the table and both examples, and a new **Typo tolerance** section explaining that the widget's `num_typos: 0` is deliberately stricter than Typesense's own default of `2` — predictable results, with the "Did you mean …?" prompt covering the misspelling case.

## One thing worth flagging

The notice uses `console.error`, not `console.warn`. The production bundle strips `warn` (the terser `drop_console` list keeps only `error`, so a failing request stays diagnosable), so a warning would have lived in the source and nowhere a publisher could ever read it — the same silence this message exists to break. I checked the built, minified bundle actually carries the string rather than trusting the source.

## Tests

9 new tests (128 in the package, all passing): the parameter absent from default and host-set params, the alias mapping, explicit `num_typos` winning, `false` leaving matching strict, the notice firing exactly once and staying quiet for configs that never mention it, the widget's `num_typos: 0` default, and the did-you-mean retry no longer sending it.

Verified end-to-end in the browser with the **minified bundle against the real Typesense**: `typo_tolerance: true` now sends `num_typos: 2`, never `typo_tolerance`, finds the mistyped post, and logs the notice once across repeated searches.

## Summary by Sourcery

Replace the unsupported `typo_tolerance` search parameter with documented `num_typos` behavior while providing compatibility guidance for existing configurations.

Bug Fixes:
- Stop forwarding the unsupported `typo_tolerance` parameter to Typesense while preserving intended legacy configurations through an alias to `num_typos: 2`.
- Ensure explicit `num_typos` values override the legacy alias and `false` retains strict matching.
- Remove the unsupported parameter from did-you-mean retry requests.

Enhancements:
- Add a once-per-key console notice for configurations that use the deprecated parameter.
- Keep the widget default at `num_typos: 0` for predictable strict matching.

Documentation:
- Update search parameter documentation and examples to present `num_typos` as the sole typo-tolerance control and explain the widget's strict default and legacy alias behavior.

Tests:
- Add coverage for parameter filtering, alias mapping, precedence, strict matching, one-time notices, defaults, and did-you-mean retries.