### PR TITLE
Open alternative layouts for a URL that already carries the search

### DIFF
--- a/packages/search-ui/src/__tests__/init.test.js
+++ b/packages/search-ui/src/__tests__/init.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '../search.js';
+
+// Loading a page whose URL already carries the search state — `#/search`,
+// `?s=…`, `?q=…` — used to hang for the palette and discovery layouts: init()
+// awaited handleInitialState(), which awaited openModal(), which awaited the
+// very promise init() was fulfilling. The modal escaped it only by timing: it
+// never suspends before handleInitialState, so `this.initReady` had not been
+// assigned yet and openModal read undefined. Any layout that loads a chunk
+// first — the only reason the promise exists — deadlocked (issue #73).
+//
+// These drive the real init() rather than the shorthand the other suites use,
+// because the cycle only exists there.
+
+// A layout stub with the surface methods init() and openModal() touch. Chunks
+// register themselves through this global, and loadLayoutFactory serves an
+// already-registered layout without a network fetch — while still awaiting,
+// which is what makes `initReady` observable and reproduced the deadlock.
+function registerLayout(id, overrides = {}) {
+  const layout = {
+    id,
+    requiredFields: () => [],
+    buildMarkup: () => `<div id="mp-search-${id}"><input class="mp-search-input" /></div>`,
+    cacheElements: vi.fn(),
+    bindEvents: vi.fn(),
+    injectStyles: vi.fn(),
+    setTheme: vi.fn(),
+    onOpen: vi.fn(),
+    onClose: vi.fn(),
+    focusInput: vi.fn(),
+    setQuery: vi.fn(),
+    getQuery: () => '',
+    renderInitial: vi.fn(),
+    renderLoading: vi.fn(),
+    renderEmpty: vi.fn(),
+    renderError: vi.fn(),
+    renderResults: vi.fn(),
+    renderSuggestions: vi.fn(),
+    renderFacets: vi.fn(),
+    ...overrides
+  };
+  window.__mpRegisterSearchLayout(id, () => layout);
+  return layout;
+}
+
+// Build an element and run init() exactly as connectedCallback does, without
+// tripping its one-time `isInitialized` guard.
+function startWidget(config = {}) {
+  const el = document.createElement('magicpages-search');
+  el.config = {
+    typesenseNodes: [{ host: 'localhost', port: '8108', protocol: 'http' }],
+    typesenseApiKey: 'search-only',
+    collectionName: 'ghost',
+    commonSearches: [],
+    pinnedSearches: [],
+    facets: [],
+    ...config
+  };
+  el.i18n = el.defaultI18n;
+  el.typesenseClient = {
+    collections: () => ({ documents: () => ({ search: async () => ({ found: 0, hits: [] }) }) })
+  };
+  el.initReady = el.init();
+  el.initReady.then(el.markSurfaceReady, el.markSurfaceReady);
+  return el;
+}
+
+// Set the URL without firing `hashchange`. Assigning `location.hash` queues one,
+// and the widget turns a hashchange into an open of its own — which would leak
+// across tests on this shared jsdom window and be mistaken for the behaviour
+// under test.
+function setUrl(suffix = '') {
+  history.replaceState(null, '', `${window.location.pathname}${suffix}`);
+}
+
+describe('initial state carried in the URL', () => {
+  beforeEach(() => {
+    setUrl();
+  });
+
+  afterEach(() => {
+    setUrl();
+    vi.restoreAllMocks();
+  });
+
+  it('opens an alternative layout for #/search instead of hanging', async () => {
+    const layout = registerLayout('palette');
+    setUrl('#/search');
+
+    const el = startWidget({ uiStyle: 'palette' });
+    // The assertion is that this settles at all: before the fix it never did.
+    await el.initReady;
+
+    expect(el.isModalOpen).toBe(true);
+    expect(layout.onOpen).toHaveBeenCalled();
+  });
+
+  it('opens the built-in modal for #/search', async () => {
+    setUrl('#/search');
+
+    const el = startWidget();
+    await el.initReady;
+
+    expect(el.isModalOpen).toBe(true);
+    expect(el.modal.classList.contains('mp-search-hidden')).toBe(false);
+  });
+
+  it('resolves openModal for a caller outside the init path', async () => {
+    registerLayout('discovery');
+    const el = startWidget({ uiStyle: 'discovery' });
+
+    // A click, ⌘K or a hash change can land before init() finishes; it must
+    // wait for the surface and then open it, not wait forever.
+    await Promise.all([el.openModal(), el.initReady]);
+
+    expect(el.isModalOpen).toBe(true);
+  });
+
+  it('still opens when mounting the layout throws, rather than stranding the caller', async () => {
+    registerLayout('palette', {
+      buildMarkup: () => { throw new Error('chunk mounted but broke'); }
+    });
+    setUrl('#/search');
+
+    const el = startWidget({ uiStyle: 'palette' });
+    await el.initReady;
+
+    // init() falls back to the built-in modal; the point is that it opened.
+    expect(el.isModalOpen).toBe(true);
+    expect(el.activeLayout).toBeNull();
+  });
+
+  it('hands a hash-path query to an alternative layout, which has no input to write to', async () => {
+    const layout = registerLayout('palette');
+    setUrl('#/search/tomato');
+
+    const el = startWidget({ uiStyle: 'palette' });
+    await el.initReady;
+
+    expect(layout.setQuery).toHaveBeenCalledWith('tomato');
+    expect(el.isModalOpen).toBe(true);
+  });
+
+  it('decodes a hash-path query the way a shared link encodes it', async () => {
+    const layout = registerLayout('palette');
+    setUrl('#/search/garden+beds');
+
+    const el = startWidget({ uiStyle: 'palette' });
+    await el.initReady;
+
+    expect(layout.setQuery).toHaveBeenCalledWith('garden beds');
+  });
+
+  it('runs a ?s= query once, not twice', async () => {
+    const queries = [];
+    const layout = registerLayout('palette');
+    setUrl('?s=tomato');
+
+    const el = startWidget({ uiStyle: 'palette' });
+    // A hit, so the zero-result path does not add a did-you-mean retry to the
+    // count — the question here is how many times the query itself was run.
+    el.typesenseClient = {
+      collections: () => ({
+        documents: () => ({
+          search: async (params) => {
+            queries.push(params.q);
+            return { found: 1, hits: [{ document: { id: 'p1', title: 'Tomatoes', url: '/p/' } }] };
+          }
+        })
+      })
+    };
+    await el.initReady;
+
+    // Opening applies the URL query; handleInitialState used to apply it again,
+    // costing a second identical request for the same search.
+    expect(layout.setQuery).toHaveBeenCalledWith('tomato');
+    expect(queries).toEqual(['tomato']);
+  });
+});

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -228,6 +228,15 @@ import Typesense from 'typesense';
             this.selectedIndex = -1;
             this.searchDebounceTimeout = null;
 
+            // Resolves once the search surface is mounted and safe to show.
+            // openModal waits on this rather than on init() as a whole: init()
+            // finishes by applying the URL-driven initial state, which may
+            // itself open the modal, so waiting on init() there would have it
+            // wait on itself.
+            this.surfaceReady = new Promise(resolve => {
+                this.markSurfaceReady = resolve;
+            });
+
             // Monotonic id of the newest query. The did-you-mean retry resolves
             // after a second request, so it checks this before rendering — a
             // suggestion for a query the reader has already typed past must
@@ -398,6 +407,10 @@ import Typesense from 'typesense';
             // expose the promise so openModal can wait for the surface to be
             // ready before showing it.
             this.initReady = this.init();
+            // A failed mount must not leave openModal waiting for a surface that
+            // will never arrive. init() marks the surface ready itself on both
+            // paths; this only covers a throw before it gets there.
+            this.initReady.then(this.markSurfaceReady, this.markSurfaceReady);
             isInitialized = true;
         }
 
@@ -734,6 +747,9 @@ import Typesense from 'typesense';
                         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
                             this.activeLayout.setTheme(this.isDarkTheme());
                         });
+                        // The surface is mounted, so anything waiting to open it
+                        // may proceed — including handleInitialState below.
+                        this.markSurfaceReady();
                         await this.handleInitialState();
                         return;
                     } catch (err) {
@@ -754,6 +770,7 @@ import Typesense from 'typesense';
             this.updateTheme();
             this.initEventListeners();
             this.setupHashHandling();
+            this.markSurfaceReady();
             await this.handleInitialState();
         }
 
@@ -1089,12 +1106,11 @@ import Typesense from 'typesense';
         async openModal() {
             if (this.isModalOpen) return;
 
-            // The surface may still be initializing (an alternative layout
-            // lazily loads its chunk). Wait for it so we never open against a
-            // half-built widget.
-            if (this.initReady) {
-                try { await this.initReady; } catch { /* fall through to modal */ }
-            }
+            // The surface may still be mounting (an alternative layout lazily
+            // loads its chunk). Wait for it so we never open against a
+            // half-built widget. This settles even when init() failed, so a
+            // broken mount shows whatever surface exists rather than hanging.
+            await this.surfaceReady;
             if (this.isModalOpen) return;
 
             // Store active element for focus restoration
@@ -1134,11 +1150,7 @@ import Typesense from 'typesense';
             const searchParams = new URLSearchParams(window.location.search);
             const searchQuery = searchParams.get('s') || searchParams.get('q');
 
-            if (searchQuery) {
-                if (this.activeLayout) this.activeLayout.setQuery(searchQuery);
-                else if (this.searchInput) this.searchInput.value = searchQuery;
-                this.handleSearch(searchQuery);
-            }
+            this.applyUrlQuery(searchQuery);
         }
 
         closeModal() {
@@ -2214,6 +2226,20 @@ import Typesense from 'typesense';
             }
         }
 
+        // Put a query carried in the URL into whichever surface is mounted and
+        // run it. The modal owns an input; an alternative layout takes it
+        // through setQuery — which is why this cannot just write to
+        // `this.searchInput`, as it is null for palette and discovery.
+        applyUrlQuery(query) {
+            if (!query) return;
+
+            if (this.activeLayout) this.activeLayout.setQuery(query);
+            else if (this.searchInput) this.searchInput.value = query;
+            else return;
+
+            this.handleSearch(query);
+        }
+
         async handleInitialState() {
             // Check for search query parameters in the URL
             const searchParams = new URLSearchParams(window.location.search);
@@ -2230,17 +2256,12 @@ import Typesense from 'typesense';
             // Prioritize hash query over URL query
             if (hashQuery) {
                 await this.openModal();
-                if (this.searchInput) {
-                    this.searchInput.value = hashQuery;
-                    this.handleSearch(hashQuery);
-                }
-            } else if (searchQuery) {
-                await this.openModal();
-                if (this.searchInput) {
-                    this.searchInput.value = searchQuery;
-                    this.handleSearch(searchQuery);
-                }
-            } else if (window.location.hash === '#/search') {
+                // openModal reads `?s=`/`?q=` from the URL itself; the hash-path
+                // form is this branch's own to apply.
+                this.applyUrlQuery(hashQuery);
+            } else if (searchQuery || window.location.hash === '#/search') {
+                // No second call for `searchQuery`: opening already ran it, and
+                // repeating it here cost a duplicate request for the same query.
                 await this.openModal();
             }
         }


### PR DESCRIPTION
Closes #73.

Loading a page at `#/search`, `?s=…` or `?q=…` never opened the search when `uiStyle` was `palette` or `discovery`. The widget mounted — markup in the shadow root, input focusable — but the panel stayed hidden and `openModal()` returned a promise that never settled. Someone following a shared search link landed on a page where search looked simply broken.

## The cycle

`connectedCallback` stores `this.initReady = this.init()`. `init()` ends by awaiting `handleInitialState()`, which awaits `openModal()`, which awaited `initReady` — the promise `init()` was still fulfilling.

The default modal escaped it by timing rather than design: it never suspends before `handleInitialState`, so the assignment had not happened yet and `openModal` read `undefined`. An alternative layout awaits its chunk first, so by then the promise existed and the wait was real.

## The fix

`openModal` now waits on the **surface being mounted** rather than on `init()` as a whole — which is what it actually needed. `init()` marks the surface ready on both paths before handling the URL-driven state, so an external caller (a click, ⌘K, a hash change) still never opens a half-built widget, and the initial state no longer waits on itself. The promise also settles when a mount throws, so a broken layout chunk falls back to the modal instead of stranding every later caller.

## Two related gaps in the same function

Both invisible until the deadlock was out of the way:

- A hash-path query (`#/search/term`) was only ever written to `this.searchInput`, which is `null` for palette and discovery — so even once they opened, a shared link's term never reached them.
- The `?s=` branch re-applied a query `openModal` had already run, costing a duplicate request for the same search.

Both now go through one `applyUrlQuery`, which knows how to reach either surface.

## Tests

New `init.test.js` (7 tests, 126 in the package): it drives the real `init()` rather than the shorthand the other suites use, because the cycle only exists there. With the old wait restored, five of the seven hang until the runner kills them.

Verified in a browser against a real Typesense: `#/search/tomato` opens the palette with the term applied and results on screen, and `?s=ghost` opens discovery the same way.

## Summary by Sourcery

Fix URL-driven search initialization so every layout opens reliably and applies shared-link queries exactly once.

Bug Fixes:
- Fix URL-driven searches so palette, discovery, and modal layouts open reliably for hash and query-string search links.
- Ensure hash-path queries reach alternative layouts and prevent duplicate searches for query-string URLs.
- Allow modal opening to proceed safely when an alternative layout fails to mount.

Enhancements:
- Coordinate modal opening with search-surface readiness rather than overall initialization.

Tests:
- Add integration coverage for real initialization, URL-driven opening, alternative-layout query handling, mount failures, and duplicate-request prevention.