### PR TITLE
chore: release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,80 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-08-19
+
+### Added
+- **"Did you mean …?" for a query that matched nothing.** The widget searches
+  strictly (`num_typos: 0`), which is what keeps results predictable — and left
+  a reader who mistyped a word with "No results found" and nowhere to go, while
+  `enableDidYouMean` sat in the config doing nothing at all. A zero-hit query is
+  now re-run once with typo tolerance raised, and if that finds posts the reader
+  is offered the corrected term: a button under the empty message in the modal
+  and discovery layouts, and a navigable row in the palette, so `↵` accepts it.
+  The suggestion comes from the `matched_tokens` the retry returned, so it is
+  always a word the site's own posts contain rather than a guess from a
+  dictionary that has never seen the archive, and words are only replaced within
+  the typo budget Typesense itself would allow for their length. The retry is
+  skipped for sites already searching with a non-zero `num_typos`, so strict
+  sites pay one extra request only on a genuine miss and lenient ones pay none.
+  Translatable via the new `didYouMeanLabel` key; turn it off with
+  `enableDidYouMean: false`.
+- **The facet rail admits when a list was cut short.** Typesense returns facet
+  values by count descending, so the display cap always dropped the least common
+  ones — a tag on two posts could never appear, even when those were the top two
+  results, which reads as "this topic doesn't exist" rather than "this list is
+  abridged". Each search now asks for one value more than it will show; that
+  extra value is never rendered, it is simply what distinguishes a cut list from
+  a complete one. Where it appears, the field gets a **Show more** control that
+  widens the list and re-runs the query, and **Show less** to collapse it, so a
+  wider rail costs one request and only when a reader asks. Both labels are
+  translatable (`facetShowMoreLabel`, `facetShowLessLabel`).
+
+### Fixed
+- **A facet's `limit` now does what it documents.** It was described as the
+  number of values shown for a field, but only fed the global
+  `max_facet_values`; the modal and the discovery rail then rendered every value
+  the response carried, so a field with `limit: 5` displayed as many values as
+  the largest facet allowed.
+- **A selected facet value can always be switched off again.** It stayed on
+  screen only while the response happened to carry it, so a value ranked below
+  what was requested lost its chip — and a filter that narrowed the results to
+  nothing lost the whole group, taking the **Clear filters** control with it and
+  leaving closing the modal as the only escape.
+- **`searchAuthors` works alongside a custom `query_by`.** It appended `authors`
+  while building the default parameters, and a host-supplied
+  `typesenseSearchParams.query_by` replaced those defaults wholesale — so the
+  documented way to make author names matchable silently did nothing for exactly
+  the sites that had tuned their query. The field is now added to the merged
+  parameters, with `query_by_weights` extended alongside it when weights are
+  configured, since Typesense rejects a search whose two lists differ in length.
+- **`typo_tolerance` is no longer treated as a Typesense parameter.** It is not
+  one, and never was: the widget sent it, this project documented it as the
+  switch for typo correction, and Typesense ignored it — so a site that set
+  `typo_tolerance: true` and stopped there kept matching strictly, with nothing
+  anywhere to say so. It is dropped from the requests, and a host-supplied value
+  is now read as the alias its author meant (`true` becomes `num_typos: 2`
+  unless `num_typos` is set explicitly) with a deprecation notice in the browser
+  console. `num_typos` is the control; the README explains why the widget's `0`
+  is deliberately stricter than Typesense's own default of `2`.
+- **The palette and discovery layouts open from a URL that already carries the
+  search.** Loading a page at `#/search`, `?s=…` or `?q=…` left the panel hidden
+  forever, because initialization waited on the state handling that was waiting
+  on initialization. Following a shared search link looked exactly like search
+  being broken. Opening now waits only for the surface to be mounted, a query in
+  the hash path reaches those layouts (it was only ever written to the modal's
+  input), and a `?s=` link no longer runs its query twice.
+- **A slow search can no longer repaint over a newer one.** Results, empty and
+  failure states all rendered unconditionally when their request returned, so an
+  earlier query that finished late could wipe the results the reader was looking
+  at — and take over click attribution with it. Failures are still logged when
+  superseded; they simply no longer reach the screen.
+
+### Changed
+- The search widget's ESLint setup moved to flat config, and the toolchain moved
+  with it (ESLint 10, typescript-eslint 8). Two rethrows in the Ghost fetch path
+  now attach the original error as `cause`, which the new rules caught.
+
 ## [2.1.0] - 2026-08-04
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "CLI tool for managing Ghost content in Typesense",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.1.0",
-    "@magicpages/ghost-typesense-core": "^2.1.0",
+    "@magicpages/ghost-typesense-config": "^2.2.0",
+    "@magicpages/ghost-typesense-core": "^2.2.0",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "ora": "^8.0.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.1.0",
-    "@magicpages/ghost-typesense-core": "^2.1.0",
+    "@magicpages/ghost-typesense-config": "^2.2.0",
+    "@magicpages/ghost-typesense-core": "^2.2.0",
     "@netlify/functions": "^2.5.1",
     "zod": "^4.4.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.1.0",
-        "@magicpages/ghost-typesense-core": "^2.1.0",
+        "@magicpages/ghost-typesense-config": "^2.2.0",
+        "@magicpages/ghost-typesense-core": "^2.2.0",
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
         "ora": "^8.0.1"
@@ -121,11 +121,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.1.0",
-        "@magicpages/ghost-typesense-core": "^2.1.0",
+        "@magicpages/ghost-typesense-config": "^2.2.0",
+        "@magicpages/ghost-typesense-core": "^2.2.0",
         "@netlify/functions": "^2.5.1",
         "zod": "^4.4.3"
       },
@@ -8245,7 +8245,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -8308,10 +8308,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.1.0",
+        "@magicpages/ghost-typesense-config": "^2.2.0",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^7.0.0",
         "typesense": "^1.7.2",
@@ -8371,7 +8371,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "typesense": "^1.7.2"
@@ -9002,8 +9002,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.1.0",
-        "@magicpages/ghost-typesense-core": "^2.1.0",
+        "@magicpages/ghost-typesense-config": "^2.2.0",
+        "@magicpages/ghost-typesense-core": "^2.2.0",
         "@types/node": "^26.2.0",
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
@@ -9089,7 +9089,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.1.0",
+        "@magicpages/ghost-typesense-config": "^2.2.0",
         "@ts-ghost/content-api": "4.2.0",
         "@ts-ghost/core-api": "^7.0.0",
         "@types/node": "^26.2.0",
@@ -9183,8 +9183,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.1.0",
-        "@magicpages/ghost-typesense-core": "^2.1.0",
+        "@magicpages/ghost-typesense-config": "^2.2.0",
+        "@magicpages/ghost-typesense-core": "^2.2.0",
         "@netlify/functions": "^2.5.1",
         "@types/node": "^26.2.0",
         "rimraf": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.1.0",
+    "@magicpages/ghost-typesense-config": "^2.2.0",
     "@ts-ghost/content-api": "4.2.0",
     "@ts-ghost/core-api": "^7.0.0",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
Cuts 2.2.0. Bumps every package and its cross-dependencies, syncs the lockfile, and adds the CHANGELOG entry.

Minor rather than patch: this adds config and i18n surface (`didYouMeanLabel`, `facetShowMoreLabel`, `facetShowLessLabel`) and two reader-facing features. Nothing was removed.

## What ships

**Added**

- **"Did you mean …?"** for a query that matched nothing. `enableDidYouMean` had been accepted and stored with nothing reading it; a zero-hit query is now retried once with typo tolerance raised, and the correction — drawn from the site's own indexed tokens, not a dictionary — is offered in all three layouts.
- **The facet rail admits when a list was cut short.** Each search asks for one value more than it displays; where that extra value comes back, a **Show more** control widens the list and re-runs the query.

**Fixed**

- A facet's `limit` now caps what is *displayed*, not just what is requested.
- A selected facet value can always be switched off again — including when the response omits it, and when a filter narrows results to nothing (which used to hide **Clear filters** along with the group).
- `searchAuthors` survives a host-supplied `typesenseSearchParams.query_by`.
- `typo_tolerance` is no longer sent to a search API that has never had such a parameter; a host-set value is read as the alias its author meant, with a deprecation notice.
- The palette and discovery layouts open from a URL that already carries the search (`#/search`, `?s=`, `?q=`) instead of hanging.
- A slow request can no longer repaint over the results of a newer one.

**Changed**

- ESLint moved to flat config (ESLint 10, typescript-eslint 8), alongside the other dependency bumps that landed this cycle.

## Verification

`lint`, `typecheck`, `test` and a forced `build` all pass on this branch — 213 tests across the workspace, 166 of them in the search UI. The built CLI reports `2.2.0`, and every publishable package still carries the `repository` field npm provenance requires.

After merge, publishing is a GitHub Release on tag `v2.2.0`, which triggers `.github/workflows/release.yml`.

## Summary by Sourcery

Release version 2.2.0 with improved search suggestions, expandable facets, more reliable filtering and URL navigation, and updated package metadata.

New Features:
- Add typo-tolerant “Did you mean?” suggestions for zero-result searches.
- Add expandable facet lists with localized Show more and Show less controls.

Bug Fixes:
- Ensure facet limits cap displayed values and selected filters remain removable even when omitted from responses or when no results remain.
- Preserve author searching with custom query fields and handle legacy typo-tolerance configuration without sending unsupported parameters.
- Fix search initialization from URL queries and prevent stale asynchronous responses from overwriting newer results.

Enhancements:
- Move the search UI linting setup to flat ESLint configuration and update the associated linting toolchain.

Build:
- Release all packages as version 2.2.0 and synchronize their cross-dependencies and lockfile.

Documentation:
- Add the 2.2.0 changelog entry documenting new search features, configuration options, fixes, and migration guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added typo-tolerant “Did you mean?” search suggestions.
  - Added expandable facet lists and support for custom author queries.
  - Added URL-driven layout opening.

- **Bug Fixes**
  - Improved facet limits and persistence.
  - Prevented stale asynchronous search results.
  - Improved handling of deprecated typo-tolerance settings and error details.

- **Chores**
  - Released version 2.2.0 across the application packages.
  - Updated linting and development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->