### PR TITLE
feat(search-ui): distinguish free-member from paid results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-08-21
+
+### Added
+- **Search results now say *which* gate a post is behind.** Every non-public
+  result carried the same "Members only" badge, which is wrong on more than half
+  of them: Ghost gates a post either to anyone who signed up or to paying
+  readers only, and a free subscriber is a member as far as they are concerned.
+  They clicked, and they hit a paywall. Results are now badged **Members** for
+  `visibility: members` and **Paid members** for `paid` and `tiers` — the latter
+  because Ghost only ever tier-restricts to paid tiers, so tier-gated content is
+  never reachable on a free account. The free badge stays quiet and the paid one
+  carries the site's accent colour in all three layouts, so the two read as a
+  pair rather than as one badge with two spellings. Both are translatable:
+  `paidLabel` / `ariaPaidLabel` join the existing `membersLabel` /
+  `ariaMembersLabel`, and the discovery preview's notice gains a
+  `discoveryPaidNotice` variant, so a publisher who calls paying readers
+  something of their own can say so. No reindex is needed — the exact
+  `visibility` was already on the indexed documents; only the widget was
+  throwing it away.
+- **`memberAwareBadges` — badge only what the reader cannot open.** Naming the
+  gate helps, but a free subscriber still has to read the badge to work out that
+  a post is not for them. With this opt-in flag the widget asks Ghost who is
+  reading (one same-origin request to `/members/api/member` when it initialises)
+  and drops the badge from anything that reader can already open: `members`
+  posts for any signed-in reader, `paid` posts for a paying one. A `tiers` post
+  keeps its badge even then, because it names specific paid tiers and the index
+  does not record which — an unverifiable promise of access is worse than a
+  redundant badge. Off by default, since the widget is also embedded on sites
+  with no Ghost member endpoint to ask. Every failure — endpoint missing, reader
+  offline, response not yet back — leaves the badges exactly as they are without
+  the flag, so nothing is ever wrongly unbadged.
+- **`data-gated` in every layout.** The `mp-search-result-gated` class and
+  `data-gated="<visibility>"` attribute are documented as the way to style a
+  gated result or route its click into a membership flow, but only the modal
+  layout actually emitted them; a site on the palette or discovery layout had
+  nothing to hook. Both now appear on the palette row, the discovery card, and
+  the discovery "Read post" link, so
+  `[data-gated="paid"], [data-gated="tiers"]` selects the paid gate whichever
+  layout is in use. They are independent of the badge: when
+  `memberAwareBadges` suppresses a badge, the gate stays on the element.
+
+### Changed
+- **`membersLabel` now defaults to "Members", not "Members only".** It is no
+  longer the label for every gate, so a name that reads as "and nothing more"
+  was misleading next to the new paid badge. An existing `membersLabel` override
+  keeps working and now applies only to `visibility: members`; sites that had
+  overridden it to cover all gated posts will want to set `paidLabel` too.
+
+### Fixed
+- The modal's gated badge interpolated its ARIA label into an attribute without
+  escaping it, unlike the same badge in the palette and discovery layouts. All
+  three now go through the escaper, so a translation containing markup or a
+  quote renders as text.
+- `example.config.json` supplied an explicit `fields` array that omitted
+  `visibility`, `tags.name`, and `tags.slug`. Only *required* fields are
+  backfilled into a config that brings its own field list, so anyone starting
+  from the example got a collection where those three were undeclared — and
+  `visibility`, which the badges read, was not facetable. The example now lists
+  them, and `@magicpages/ghost-typesense-config`'s README documents the
+  backfill rule instead of a stale field list.
+
 ## [2.2.0] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   redundant badge. Off by default, since the widget is also embedded on sites
   with no Ghost member endpoint to ask. Every failure — endpoint missing, reader
   offline, response not yet back — leaves the badges exactly as they are without
-  the flag, so nothing is ever wrongly unbadged.
+  the flag, so nothing is ever wrongly unbadged. The path is configurable via
+  `memberEndpoint`: the default assumes Ghost sits at the origin root, and a
+  subdirectory install or a path-rewriting proxy needs its own prefix.
 - **`data-gated` in every layout.** The `mp-search-result-gated` class and
   `data-gated="<visibility>"` attribute are documented as the way to style a
   gated result or route its click into a membership flow, but only the modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   redundant badge. Off by default, since the widget is also embedded on sites
   with no Ghost member endpoint to ask. Every failure — endpoint missing, reader
   offline, response not yet back — leaves the badges exactly as they are without
-  the flag, so nothing is ever wrongly unbadged. The path is configurable via
-  `memberEndpoint`: the default assumes Ghost sits at the origin root, and a
-  subdirectory install or a path-rewriting proxy needs its own prefix.
+  the flag, so nothing is ever wrongly unbadged. The lookup is fired when the
+  widget initialises and never awaited, so it costs no search latency; a fast
+  reader on a slow connection who gets results before it lands sees them badged
+  for an unknown reader, and the query is re-run once when the answer arrives.
+  The path is configurable via `memberEndpoint`: the default assumes Ghost sits
+  at the origin root, and a subdirectory install or a path-rewriting proxy needs
+  its own prefix.
 - **`data-gated` in every layout.** The `mp-search-result-gated` class and
   `data-gated="<visibility>"` attribute are documented as the way to style a
   gated result or route its click into a membership flow, but only the modal

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ With it enabled:
 
 - Non-public posts (`members`, `paid`, tier-restricted) are indexed with their **title, excerpt, URL, tags, and feature image**, plus a `visibility` field.
 - The searchable text is limited to the public excerpt (falling back to the title). The post's body is **never read or indexed** — this package uses Ghost's Content API, which only ever returns the public preview for gated posts, and the indexer ignores the body regardless. There is no protected text in the index to leak.
-- The search UI marks these results with a "members only" badge (see the [search-ui README](packages/search-ui/README.md#members-only-results)), turning gated posts into discoverable lead magnets.
+- The search UI badges these results by gate — **Members** for anything a free signup can read, **Paid members** for paid and tier-restricted posts (see [gated results](packages/search-ui/README.md#gated-results)) — turning gated posts into discoverable lead magnets without sending a free subscriber somewhere they cannot read.
 
 For real-time updates, set `INDEX_GATED_CONTENT=true` on the webhook handler to mirror this behaviour.
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "CLI tool for managing Ghost content in Typesense",
   "repository": {
     "type": "git",

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -99,6 +99,15 @@
           <label><input type="checkbox" id="opt-suggestions" /> Pinned + common suggestions</label>
           <label><input type="checkbox" id="opt-semantic" /> Semantic search</label>
           <label><input type="checkbox" id="opt-analytics" checked /> Analytics (logged below)</label>
+          <label><input type="checkbox" id="opt-memberaware" /> Member-aware badges</label>
+          <label>Signed-in reader
+            <select id="opt-reader">
+              <option value="anonymous">signed out</option>
+              <option value="free">free member</option>
+              <option value="paid">paying member</option>
+              <option value="none">no member endpoint</option>
+            </select>
+          </label>
         </div>
         <div class="row">
           <label>Real Typesense endpoint (optional)

--- a/apps/playground/src/main.js
+++ b/apps/playground/src/main.js
@@ -13,6 +13,8 @@ const els = {
   suggestions: document.getElementById('opt-suggestions'),
   semantic: document.getElementById('opt-semantic'),
   analytics: document.getElementById('opt-analytics'),
+  memberAware: document.getElementById('opt-memberaware'),
+  reader: document.getElementById('opt-reader'),
   endpoint: document.getElementById('opt-endpoint'),
   apply: document.getElementById('apply'),
   open: document.getElementById('open'),
@@ -188,6 +190,9 @@ function buildConfig(backend) {
   if (els.analytics.checked) {
     config.analytics = { endpoint: ANALYTICS_ENDPOINT, siteId: 'playground' };
   }
+  if (els.memberAware && els.memberAware.checked) {
+    config.memberAwareBadges = true;
+  }
   return config;
 }
 
@@ -208,6 +213,8 @@ function readControls() {
     suggestions: els.suggestions.checked,
     semantic: els.semantic.checked,
     analytics: els.analytics.checked,
+    memberAware: els.memberAware ? els.memberAware.checked : false,
+    reader: els.reader ? els.reader.value : 'anonymous',
     endpoint: els.endpoint.value.trim()
   };
 }
@@ -222,12 +229,23 @@ function restoreControls(state) {
   els.suggestions.checked = !!state.suggestions;
   els.semantic.checked = !!state.semantic;
   els.analytics.checked = state.analytics !== false;
+  if (els.memberAware) els.memberAware.checked = !!state.memberAware;
+  if (els.reader) els.reader.value = state.reader ?? 'anonymous';
   els.endpoint.value = state.endpoint ?? '';
+}
+
+// The dev server answers /members/api/member from this cookie, standing in for
+// Ghost's own member session so the reader-aware badges can be stepped through
+// signed out → free → paying without a Ghost install.
+function applyReaderCookie(reader) {
+  document.cookie = `pg_reader=${encodeURIComponent(reader || 'anonymous')}; path=/`;
 }
 
 function apply() {
   // Persist the chosen options and reload; loadWidget() picks them up.
-  sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ ...readControls(), open: true }));
+  const controls = readControls();
+  applyReaderCookie(controls.reader);
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ ...controls, open: true }));
   location.reload();
 }
 

--- a/apps/playground/src/mock.js
+++ b/apps/playground/src/mock.js
@@ -81,6 +81,20 @@ export const POSTS = [
     tags: ['Ghost', 'Design'],
     authors: ['Sam'],
     visibility: 'paid'
+  },
+  {
+    id: 'post-7',
+    title: 'Founding member workshop: designing a Ghost theme',
+    slug: 'founding-member-workshop',
+    url: 'https://demo.example.com/founding-member-workshop/',
+    excerpt: 'A workshop recording for readers on the founding tier.',
+    plaintext: 'TIERS_BODY: handlebars partials, routing, and a full theme walkthrough.',
+    published_at: 1694000000000,
+    tags: ['Design'],
+    authors: ['Jannis'],
+    // Ghost reports tier-restricted posts as 'tiers', and only ever paid tiers,
+    // so the widget badges them as paid.
+    visibility: 'tiers'
   }
 ];
 

--- a/apps/playground/vite.config.js
+++ b/apps/playground/vite.config.js
@@ -73,9 +73,50 @@ function mockTypesense() {
   };
 }
 
+/**
+ * Stand in for Ghost's member session endpoint, so the widget's reader-aware
+ * badges can be exercised without a Ghost install. The playground's "Signed-in
+ * reader" control sets a `pg_reader` cookie; this answers the way Ghost does —
+ * 204 for a signed-out reader, a member payload otherwise — and 404s when asked
+ * to behave like a site that has no member endpoint at all.
+ */
+function mockGhostMember() {
+  const PAYLOADS = {
+    free: { uuid: 'pg-free', email: 'free@example.com', status: 'free', paid: false, subscriptions: [] },
+    paid: { uuid: 'pg-paid', email: 'paid@example.com', status: 'paid', paid: true, subscriptions: [] }
+  };
+
+  return {
+    name: 'mock-ghost-member',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!/^\/members\/api\/member\/?(\?|$)/.test(req.url ?? '')) return next();
+
+        const cookie = /(?:^|;\s*)pg_reader=([^;]*)/.exec(req.headers.cookie ?? '');
+        const reader = cookie ? decodeURIComponent(cookie[1]) : 'anonymous';
+
+        res.setHeader('Cache-Control', 'no-store');
+        if (reader === 'none') {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+        if (!PAYLOADS[reader]) {
+          res.statusCode = 204;
+          res.end();
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.end(JSON.stringify(PAYLOADS[reader]));
+      });
+    }
+  };
+}
+
 export default defineConfig({
   root: __dirname,
-  plugins: [serveSearchBundle(), mockTypesense()],
+  plugins: [serveSearchBundle(), mockTypesense(), mockGhostMember()],
   server: {
     port: 5174,
     open: true,

--- a/apps/playground/vite.config.js
+++ b/apps/playground/vite.config.js
@@ -92,8 +92,18 @@ function mockGhostMember() {
       server.middlewares.use((req, res, next) => {
         if (!/^\/members\/api\/member\/?(\?|$)/.test(req.url ?? '')) return next();
 
+        // decodeURIComponent throws URIError on malformed percent-encoding, which
+        // would take the middleware down before it answers. A cookie we cannot
+        // read is a reader we cannot identify, so fall back to signed out.
         const cookie = /(?:^|;\s*)pg_reader=([^;]*)/.exec(req.headers.cookie ?? '');
-        const reader = cookie ? decodeURIComponent(cookie[1]) : 'anonymous';
+        let reader = 'anonymous';
+        if (cookie) {
+          try {
+            reader = decodeURIComponent(cookie[1]);
+          } catch {
+            reader = 'anonymous';
+          }
+        }
 
         res.setHeader('Cache-Control', 'no-store');
         if (reader === 'none') {

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",

--- a/example.config.json
+++ b/example.config.json
@@ -67,8 +67,28 @@
         "optional": true
       },
       {
+        "name": "tags.name",
+        "type": "string[]",
+        "index": true,
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "tags.slug",
+        "type": "string[]",
+        "index": true,
+        "facet": true,
+        "optional": true
+      },
+      {
         "name": "authors",
         "type": "string[]",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "visibility",
+        "type": "string",
         "facet": true,
         "optional": true
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -72,9 +72,17 @@ The package includes default fields optimized for Ghost content, including:
 
 // Optional fields
 { name: 'feature_image', type: 'string', optional: true }
-{ name: 'tags', type: 'string[]', optional: true }
-{ name: 'authors', type: 'string[]', optional: true }
+{ name: 'tags', type: 'string[]', facet: true, optional: true }
+{ name: 'tags.name', type: 'string[]', index: true, facet: true, optional: true }
+{ name: 'tags.slug', type: 'string[]', index: true, facet: true, optional: true }
+{ name: 'authors', type: 'string[]', facet: true, optional: true }
+{ name: 'visibility', type: 'string', facet: true, optional: true }
 ```
+
+Only the **required** fields are backfilled into a config that supplies its own
+`fields` array. If you replace the list, carry over any optional field you still
+want — `visibility` in particular, which the search UI reads to tell a
+free-member post from a paid one.
 
 ## Types
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -317,6 +317,21 @@ describe('GhostTypesenseManager — gated content redaction', () => {
     expect(doc.tags).toEqual(['Premium']);
   });
 
+  // The search UI distinguishes a free-member gate from a paid one, so Ghost's
+  // exact visibility has to survive redaction rather than collapsing to a
+  // generic "gated". 'tiers' is what Ghost reports for tier-restricted posts.
+  it.each(['paid', 'tiers'])('keeps a %s post\'s own visibility on the redacted document', (visibility) => {
+    const manager = new GhostTypesenseManager({
+      ...baseConfig,
+      collection: { ...baseConfig.collection, indexGatedContent: true }
+    });
+    const doc = transform(manager, { ...gatedPost, visibility });
+
+    expect(doc.visibility).toBe(visibility);
+    expect(doc.html).toBe('');
+    expect(JSON.stringify(doc)).not.toContain('SECRET_PROTECTED_BODY');
+  });
+
   it('falls back to the title when a gated post has no excerpt', () => {
     const manager = new GhostTypesenseManager({
       ...baseConfig,

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -99,6 +99,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `semanticDistanceThreshold` | `Number` | No | `0.8` | Drop vector matches whose cosine distance exceeds this when `semanticSearch` is on; lower is stricter |
 | `facets` | `Array` | No | `[]` | Reader-facing filter controls for faceted fields (see [Filters](#filters)) |
 | `memberAwareBadges` | `Boolean` | No | `false` | Ask Ghost who is reading, and drop the gated badge from posts this reader can already open (see [Gated results](#gated-results)) |
+| `memberEndpoint` | `String` | No | `'/members/api/member'` | Path of Ghost's member-session endpoint, for a subdirectory install or a path-rewriting proxy |
 | `uiStyle` | `String` | No | `'modal'` | Overall layout: `'modal'`, `'palette'`, or `'discovery'` (see [UI layouts](#ui-layouts)) |
 | `template` | `String` | No | `'list'` | Modal result layout: `'list'` or `'grid'` (see [Result templates](#result-templates)) |
 | `searchAuthors` | `Boolean` | No | `false` | Make author names matchable by keyword (see [Searchable fields](#searchable-fields)) |
@@ -448,6 +449,15 @@ A free subscriber is a "member" as far as they are concerned, so a badge that ju
 A `tiers` post keeps its badge even for a paying reader: it names specific paid tiers, and the index does not record which, so the widget will not promise access it cannot verify.
 
 It is **off by default**. Turn it on only on a Ghost site — anywhere else the endpoint does not exist. Every failure (endpoint missing, reader offline, response not yet back) leaves the badges exactly as they are without it, so nothing is ever wrongly unbadged. `data-gated` is unaffected: the gate stays on the element for your theme code whether or not the badge is shown.
+
+The default path assumes Ghost is served from the origin root. On a subdirectory install, or behind a proxy that rewrites paths, point `memberEndpoint` at the right place:
+
+```js
+memberAwareBadges: true,
+memberEndpoint: '/blog/members/api/member'
+```
+
+Keep it same-origin. The lookup is sent with `credentials: 'same-origin'`, so a cross-origin URL arrives without the reader's Ghost session cookie and every reader looks signed out.
 
 ## Semantic search
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -98,6 +98,7 @@ window.__MP_SEARCH_CONFIG__ = {
 | `semanticAlpha` | `Number` | No | `0.2` | Vector weight in hybrid rank fusion when `semanticSearch` is on; lower favours keyword matches (see [Keeping hybrid results relevant](#keeping-hybrid-results-relevant)) |
 | `semanticDistanceThreshold` | `Number` | No | `0.8` | Drop vector matches whose cosine distance exceeds this when `semanticSearch` is on; lower is stricter |
 | `facets` | `Array` | No | `[]` | Reader-facing filter controls for faceted fields (see [Filters](#filters)) |
+| `memberAwareBadges` | `Boolean` | No | `false` | Ask Ghost who is reading, and drop the gated badge from posts this reader can already open (see [Gated results](#gated-results)) |
 | `uiStyle` | `String` | No | `'modal'` | Overall layout: `'modal'`, `'palette'`, or `'discovery'` (see [UI layouts](#ui-layouts)) |
 | `template` | `String` | No | `'list'` | Modal result layout: `'list'` or `'grid'` (see [Result templates](#result-templates)) |
 | `searchAuthors` | `Boolean` | No | `false` | Make author names matchable by keyword (see [Searchable fields](#searchable-fields)) |
@@ -400,13 +401,53 @@ Typesense's `max_facet_values` is a single global parameter, so it is sized by t
 
 The **palette** layout is unaffected: its Tags and Authors groups are query shortcuts capped at six rows by the layout itself, not the configurable filter rail.
 
-## Members-only results
+## Gated results
 
-When the index includes gated (members-only / paid) posts — see [indexing members-only content](../../README.md#members-only-content) on the indexing side — the widget marks those results with a small **"members only"** badge. No widget configuration is needed; it keys off the `visibility` field on each result and requests that field automatically.
+When the index includes gated posts — see [indexing members-only content](../../README.md#members-only-content) on the indexing side — the widget badges them. Ghost gates a post two ways, and the badge says which:
 
-Gated results carry a `mp-search-result-gated` class and a `data-gated="<visibility>"` attribute on the result link, so you can style them or wire clicks to a membership/upsell flow with your own theme code. The badge text is translatable via the `membersLabel` / `ariaMembersLabel` keys (see [Internationalization](#internationalization-i18n)).
+| Ghost `visibility` | Badge | Meaning |
+| --- | --- | --- |
+| `public` | none | anyone can read it |
+| `members` | **Members** | any signed-up reader, free included |
+| `paid` | **Paid members** | paying readers only |
+| `tiers` | **Paid members** | specific paid tiers only |
+
+`tiers` badges as paid because Ghost only ever tier-restricts to *paid* tiers — tier-gated content is never reachable on a free account.
+
+No configuration is needed. The widget keys off the `visibility` field on each result and requests that field automatically.
+
+Both labels are translatable — `membersLabel` / `ariaMembersLabel` and `paidLabel` / `ariaPaidLabel` (see [Internationalization](#internationalization-i18n)) — so if you call your paying readers something else, say so:
+
+```js
+i18n: {
+  membersLabel: 'Subscribers',
+  paidLabel: 'Supporters',
+  ariaPaidLabel: 'Content for supporters only'
+}
+```
+
+Gated results carry a `mp-search-result-gated` class and a `data-gated="<visibility>"` attribute on the result element in every layout, so you can style them or wire clicks to a membership/upsell flow with your own theme code:
+
+```css
+.mp-search-result-gated[data-gated="paid"],
+.mp-search-result-gated[data-gated="tiers"] { /* the paid gate */ }
+```
 
 Because gated posts are indexed as redacted documents (excerpt/preview only), there is no protected body text in the results to expose.
+
+### Badging only what the reader cannot open
+
+A free subscriber is a "member" as far as they are concerned, so a badge that just says *members* still sends them to posts they cannot read. Set `memberAwareBadges: true` and the widget asks Ghost who is reading — one same-origin request to `/members/api/member` when it initialises — and drops the badge from anything that reader can already open:
+
+| Post | signed out | free member | paying member |
+| --- | --- | --- | --- |
+| `members` | badge | — | — |
+| `paid` | badge | badge | — |
+| `tiers` | badge | badge | badge |
+
+A `tiers` post keeps its badge even for a paying reader: it names specific paid tiers, and the index does not record which, so the widget will not promise access it cannot verify.
+
+It is **off by default**. Turn it on only on a Ghost site — anywhere else the endpoint does not exist. Every failure (endpoint missing, reader offline, response not yet back) leaves the badges exactly as they are without it, so nothing is ever wrongly unbadged. `data-gated` is unaffected: the gate stays on the element for your theme code whether or not the badge is shown.
 
 ## Semantic search
 
@@ -597,8 +638,10 @@ window.__MP_SEARCH_CONFIG__ = {
 | `clearFiltersLabel` | "Clear filters" | Label for the button that clears active facet filters |
 | `facetShowMoreLabel` | "Show more" | Control shown under a facet whose value list was cut short |
 | `facetShowLessLabel` | "Show less" | Collapses an expanded facet back to its configured limit |
-| `membersLabel` | "Members only" | Badge text on gated (members-only / paid) results |
-| `ariaMembersLabel` | "Members-only content" | ARIA label for the members-only badge |
+| `membersLabel` | "Members" | Badge text on posts open to any signed-up reader |
+| `ariaMembersLabel` | "Members-only content" | ARIA label for that badge |
+| `paidLabel` | "Paid members" | Badge text on paid and tier-restricted posts |
+| `ariaPaidLabel` | "Paid-members-only content" | ARIA label for that badge |
 | `untitledPost` | "Untitled" | Fallback for posts without titles |
 | `relativeNow` / `relativeMinutes` / `relativeHours` / `relativeDays` / `relativeMonths` / `relativeYears` | "just now" / "{n}m ago" / … | Relative dates in result rows (`{n}` is substituted) |
 

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1571,6 +1571,20 @@ describe('reader membership lookup', () => {
     expect(await el.resolveReaderAccess()).toBe('unknown');
   });
 
+  // Ghost can live under a subdirectory, or behind a proxy that rewrites paths.
+  // Hard-coding the origin-root path would 404 there, and a 404 reads as "no
+  // member endpoint" — every gated post silently keeps its badge.
+  it('honours a configured endpoint for a subdirectory install', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 204, ok: true });
+    const el = mountWithConfig({
+      memberAwareBadges: true,
+      memberEndpoint: '/blog/members/api/member'
+    });
+
+    await el.resolveReaderAccess();
+    expect(global.fetch.mock.calls[0][0]).toBe('/blog/members/api/member');
+  });
+
   it('asks once per page, however often it is called', async () => {
     global.fetch = vi.fn().mockResolvedValue({ status: 204, ok: true });
     const el = mountWithConfig({ memberAwareBadges: true });

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1585,6 +1585,40 @@ describe('reader membership lookup', () => {
     expect(global.fetch.mock.calls[0][0]).toBe('/blog/members/api/member');
   });
 
+  // The lookup is fired at init and never awaited, so a fast reader on a slow
+  // connection can get results badged for an unknown reader. Re-running the
+  // query when the answer lands is what stops that badge sticking around.
+  it('re-runs the query when a signed-in reader resolves after a render', async () => {
+    let settle;
+    global.fetch = vi.fn(() => new Promise((resolve) => { settle = resolve; }));
+    const el = mountWithConfig({ memberAwareBadges: true });
+    el.rerunQuery = vi.fn();
+    el.searchInput.value = 'composting';
+
+    const pending = el.resolveReaderAccess();
+    // Rendered while still unknown: every gate keeps its badge.
+    expect(el.needsBadge('members')).toBe(true);
+    expect(el.rerunQuery).not.toHaveBeenCalled();
+
+    settle({ status: 200, ok: true, json: () => Promise.resolve({ status: 'free', paid: false }) });
+    await pending;
+
+    expect(el.needsBadge('members')).toBe(false);
+    expect(el.rerunQuery).toHaveBeenCalledTimes(1);
+  });
+
+  // Most traffic is signed out, and a signed-out reader is badged exactly like
+  // an unresolved one — so re-running would cost a request and change nothing.
+  it('does not re-run for a signed-out reader', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 204, ok: true });
+    const el = mountWithConfig({ memberAwareBadges: true });
+    el.rerunQuery = vi.fn();
+
+    await el.resolveReaderAccess();
+
+    expect(el.rerunQuery).not.toHaveBeenCalled();
+  });
+
   it('asks once per page, however often it is called', async () => {
     global.fetch = vi.fn().mockResolvedValue({ status: 204, ok: true });
     const el = mountWithConfig({ memberAwareBadges: true });

--- a/packages/search-ui/src/__tests__/component.test.js
+++ b/packages/search-ui/src/__tests__/component.test.js
@@ -1360,3 +1360,224 @@ describe('searchAuthors', () => {
     expect(params.query_by_weights).toBe('5,1,1');
   });
 });
+
+// Ghost gates a post two ways — anyone signed up, or paying readers only — and
+// a single "members only" badge conflates them, which sends a free subscriber
+// to a post they cannot read.
+describe('accessLevel — Ghost visibility to the gate a reader hits', () => {
+  const level = (visibility) => mountWithConfig().accessLevel(visibility);
+
+  it('reports no gate on a public post', () => {
+    expect(level('public')).toBe('public');
+  });
+
+  it('maps members to the free-member gate', () => {
+    expect(level('members')).toBe('members');
+  });
+
+  it('maps paid to the paid gate', () => {
+    expect(level('paid')).toBe('paid');
+  });
+
+  // Ghost filters a tiers post's tier list down to paid tiers when it
+  // serialises the post, so tier-gated content is never reachable for free.
+  it('maps tiers to the paid gate', () => {
+    expect(level('tiers')).toBe('paid');
+  });
+
+  it('treats a missing visibility as public, matching the indexer default', () => {
+    expect(level(undefined)).toBe('public');
+    expect(level('')).toBe('public');
+  });
+
+  it('falls back to the weaker claim on an unrecognised gate', () => {
+    expect(level('something-new')).toBe('members');
+  });
+});
+
+describe('needsBadge — suppressed only where access is certain', () => {
+  function el(readerAccess) {
+    const element = mountWithConfig({ memberAwareBadges: true });
+    element.readerAccess = readerAccess;
+    return element;
+  }
+
+  it('badges every gate while the reader is unknown', () => {
+    const unknown = el('unknown');
+    expect(unknown.needsBadge('members')).toBe(true);
+    expect(unknown.needsBadge('paid')).toBe(true);
+    expect(unknown.needsBadge('tiers')).toBe(true);
+  });
+
+  it('badges every gate for a signed-out reader', () => {
+    const anonymous = el('anonymous');
+    expect(anonymous.needsBadge('members')).toBe(true);
+    expect(anonymous.needsBadge('paid')).toBe(true);
+    expect(anonymous.needsBadge('tiers')).toBe(true);
+  });
+
+  it('drops the members badge for a free member, but keeps the paid ones', () => {
+    const free = el('free');
+    expect(free.needsBadge('members')).toBe(false);
+    expect(free.needsBadge('paid')).toBe(true);
+    expect(free.needsBadge('tiers')).toBe(true);
+  });
+
+  // A tiers post names specific paid tiers, and the index does not record which,
+  // so a paying reader keeps the badge rather than being promised access we
+  // cannot verify.
+  it('drops members and paid badges for a paying reader, but never tiers', () => {
+    const paid = el('paid');
+    expect(paid.needsBadge('members')).toBe(false);
+    expect(paid.needsBadge('paid')).toBe(false);
+    expect(paid.needsBadge('tiers')).toBe(true);
+  });
+
+  it('never badges a public post, whoever is reading', () => {
+    for (const reader of ['unknown', 'anonymous', 'free', 'paid']) {
+      expect(el(reader).needsBadge('public')).toBe(false);
+    }
+  });
+});
+
+describe('gatedBadge', () => {
+  it('renders nothing without a gate', () => {
+    const el = mountWithConfig();
+    expect(el.gatedBadge('public')).toBe('');
+    expect(el.gatedBadge(undefined)).toBe('');
+  });
+
+  it('labels the free-member gate and marks it as such', () => {
+    const dom = parse(mountWithConfig().gatedBadge('members'));
+    const badge = dom.querySelector('.mp-search-gated-badge');
+    expect(badge.classList.contains('mp-search-gated-badge-members')).toBe(true);
+    expect(badge.textContent).toContain('Members');
+    expect(badge.textContent).not.toContain('Paid');
+    expect(badge.getAttribute('aria-label')).toBe('Members-only content');
+  });
+
+  it('labels the paid gate distinctly', () => {
+    const dom = parse(mountWithConfig().gatedBadge('paid'));
+    const badge = dom.querySelector('.mp-search-gated-badge');
+    expect(badge.classList.contains('mp-search-gated-badge-paid')).toBe(true);
+    expect(badge.textContent).toContain('Paid members');
+    expect(badge.getAttribute('aria-label')).toBe('Paid-members-only content');
+  });
+
+  // Both labels come from the site's own translations, so they are text — the
+  // same contract every other translated string in the widget follows.
+  it('renders a label containing markup as text, never as markup', () => {
+    const el = mountWithConfig();
+    el.i18n = { ...el.defaultI18n, paidLabel: '<img src=x onerror=alert(1)>' };
+    const dom = parse(el.gatedBadge('paid'));
+
+    expect(dom.querySelector('img')).toBeNull();
+    expect(dom.querySelector('.mp-search-gated-badge').textContent)
+      .toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('lets a publisher use their own word for a paying reader', () => {
+    const el = mountWithConfig();
+    el.i18n = { ...el.defaultI18n, paidLabel: 'Supporters' };
+    expect(parse(el.gatedBadge('paid')).querySelector('.mp-search-gated-badge').textContent)
+      .toContain('Supporters');
+  });
+});
+
+describe('normalizeHit — the gate handed to alternative layouts', () => {
+  function hitWith(visibility) {
+    return { document: { id: 'p1', title: 'A post', excerpt: 'Teaser', visibility } };
+  }
+
+  it('carries the access bucket so no layout has to re-derive it', () => {
+    const el = mountWithConfig();
+    expect(el.normalizeHit(hitWith('tiers'), 0).access).toBe('paid');
+    expect(el.normalizeHit(hitWith('members'), 0).access).toBe('members');
+    expect(el.normalizeHit(hitWith('public'), 0).access).toBe('public');
+  });
+
+  it('carries the per-reader badge decision alongside it', () => {
+    const el = mountWithConfig({ memberAwareBadges: true });
+    el.readerAccess = 'free';
+
+    const members = el.normalizeHit(hitWith('members'), 0);
+    expect(members.isGated).toBe(true);
+    expect(members.showBadge).toBe(false);
+    expect(el.normalizeHit(hitWith('paid'), 0).showBadge).toBe(true);
+  });
+});
+
+describe('reader membership lookup', () => {
+  let realFetch;
+  beforeEach(() => {
+    realFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  function memberResponse(body) {
+    return { status: 200, ok: true, json: () => Promise.resolve(body) };
+  }
+
+  it('never asks Ghost while the flag is off', async () => {
+    global.fetch = vi.fn();
+    const el = mountWithConfig();
+
+    expect(await el.resolveReaderAccess()).toBe('unknown');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('reads a signed-out reader from the 204', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 204, ok: true });
+    const el = mountWithConfig({ memberAwareBadges: true });
+
+    expect(await el.resolveReaderAccess()).toBe('anonymous');
+    expect(el.readerAccess).toBe('anonymous');
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe('/members/api/member');
+    expect(init.credentials).toBe('same-origin');
+    expect(init.cache).toBe('no-store');
+  });
+
+  it('reads a free member', async () => {
+    global.fetch = vi.fn().mockResolvedValue(memberResponse({ status: 'free', paid: false }));
+    const el = mountWithConfig({ memberAwareBadges: true });
+
+    expect(await el.resolveReaderAccess()).toBe('free');
+  });
+
+  // Ghost's own payload sets `paid` for comped members too, so a complimentary
+  // subscription is treated as paying — which it is, for access.
+  it('reads a paying member, comped included', async () => {
+    global.fetch = vi.fn().mockResolvedValue(memberResponse({ status: 'comped', paid: true }));
+    const el = mountWithConfig({ memberAwareBadges: true });
+
+    expect(await el.resolveReaderAccess()).toBe('paid');
+  });
+
+  it('stays unknown when the request fails, so nothing is wrongly unbadged', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('offline'));
+    const el = mountWithConfig({ memberAwareBadges: true });
+
+    expect(await el.resolveReaderAccess()).toBe('unknown');
+    expect(el.needsBadge('paid')).toBe(true);
+  });
+
+  it('stays unknown on a site with no member endpoint', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 404, ok: false });
+    const el = mountWithConfig({ memberAwareBadges: true });
+
+    expect(await el.resolveReaderAccess()).toBe('unknown');
+  });
+
+  it('asks once per page, however often it is called', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 204, ok: true });
+    const el = mountWithConfig({ memberAwareBadges: true });
+
+    await Promise.all([el.resolveReaderAccess(), el.resolveReaderAccess()]);
+    await el.resolveReaderAccess();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/search-ui/src/__tests__/discovery.test.js
+++ b/packages/search-ui/src/__tests__/discovery.test.js
@@ -55,6 +55,8 @@ function modelWith(featureImage) {
       ariaTitle: 'A post',
       excerptHtml: 'Body teaser',
       isGated: false,
+      access: 'public',
+      showBadge: false,
       visibility: 'public',
       featureImage,
       tags: ['Gardening'],
@@ -342,5 +344,111 @@ describe('discovery facet truncation', () => {
 
     expect(shadow.querySelectorAll('.mp-search-discovery-facet-chip')).toHaveLength(11);
     expect(shadow.querySelector('.mp-search-discovery-facet-more')).toBeNull();
+  });
+});
+
+// Ghost gates a post two ways — anyone signed up, or paying readers only — and
+// the discovery rail has to tell them apart in both the card list and the
+// preview pane.
+describe('discovery gated results', () => {
+  // Mirrors what normalizeHit hands the layout. `showBadge` is the core's
+  // per-reader decision; `access` is the gate itself.
+  function gatedModel({ visibility, access, showBadge = true }) {
+    return [
+      {
+        id: 'p1',
+        position: 0,
+        url: '/post/',
+        title: 'A post',
+        titleHtml: 'A post',
+        ariaTitle: 'A post',
+        excerptHtml: 'Body teaser',
+        isGated: true,
+        access,
+        showBadge,
+        visibility,
+        featureImage: null,
+        tags: ['Gardening'],
+        authors: ['Ada Lovelace'],
+        publishedAt: 1700000000000
+      }
+    ];
+  }
+
+  // makeCtx().t echoes the key, so the keys themselves are the assertion.
+  it('labels a free-member card distinctly from a paid one', () => {
+    const free = mountDiscovery();
+    free.layout.renderResults(gatedModel({ visibility: 'members', access: 'members' }), { found: 1 });
+    const freeBadge = free.shadow
+      .getElementById('mp-search-discovery-results')
+      .querySelector('.mp-search-gated-badge');
+    expect(freeBadge.classList.contains('mp-search-gated-badge-members')).toBe(true);
+    expect(freeBadge.textContent).toContain('membersLabel');
+
+    const paid = mountDiscovery();
+    paid.layout.renderResults(gatedModel({ visibility: 'paid', access: 'paid' }), { found: 1 });
+    const paidBadge = paid.shadow
+      .getElementById('mp-search-discovery-results')
+      .querySelector('.mp-search-gated-badge');
+    expect(paidBadge.classList.contains('mp-search-gated-badge-paid')).toBe(true);
+    expect(paidBadge.textContent).toContain('paidLabel');
+    expect(paidBadge.getAttribute('aria-label')).toBe('ariaPaidLabel');
+  });
+
+  it('badges the preview byline with the same gate', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(gatedModel({ visibility: 'tiers', access: 'paid' }), { found: 1 });
+
+    const byline = shadow.querySelector('.mp-search-discovery-preview-byline');
+    expect(byline.querySelector('.mp-search-gated-badge-paid')).not.toBeNull();
+  });
+
+  it('matches the preview notice wording to the gate', () => {
+    const free = mountDiscovery();
+    free.layout.renderResults(gatedModel({ visibility: 'members', access: 'members' }), { found: 1 });
+    expect(free.shadow.querySelector('.mp-search-discovery-gated-notice').textContent)
+      .toBe('discoveryGatedNotice');
+
+    const paid = mountDiscovery();
+    paid.layout.renderResults(gatedModel({ visibility: 'paid', access: 'paid' }), { found: 1 });
+    expect(paid.shadow.querySelector('.mp-search-discovery-gated-notice').textContent)
+      .toBe('discoveryPaidNotice');
+  });
+
+  // The notice explains why the preview is only a teaser, which is a property of
+  // the indexed document — true whether or not this reader can open the post.
+  it('keeps the notice for a reader who no longer needs the badge', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(
+      gatedModel({ visibility: 'members', access: 'members', showBadge: false }),
+      { found: 1 }
+    );
+
+    expect(shadow.querySelector('.mp-search-discovery-gated-notice')).not.toBeNull();
+    expect(shadow.querySelector('.mp-search-gated-badge')).toBeNull();
+  });
+
+  // Same contract the modal layout offers, so theme code can style a gate or
+  // route the click to a membership flow whichever layout is in use.
+  it('exposes the raw visibility on the card and the read-post link', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(gatedModel({ visibility: 'tiers', access: 'paid' }), { found: 1 });
+
+    const card = shadow.querySelector('.mp-search-discovery-card');
+    expect(card.getAttribute('data-gated')).toBe('tiers');
+    expect(card.classList.contains('mp-search-result-gated')).toBe(true);
+
+    const open = shadow.querySelector('.mp-search-discovery-open');
+    expect(open.getAttribute('data-gated')).toBe('tiers');
+    expect(open.classList.contains('mp-search-result-gated')).toBe(true);
+  });
+
+  it('leaves a public result unbadged and unmarked', () => {
+    const { layout, shadow } = mountDiscovery();
+    layout.renderResults(modelWith(null), { found: 1 });
+
+    expect(shadow.querySelector('.mp-search-gated-badge')).toBeNull();
+    expect(shadow.querySelector('.mp-search-discovery-gated-notice')).toBeNull();
+    expect(shadow.querySelector('.mp-search-discovery-card').hasAttribute('data-gated')).toBe(false);
   });
 });

--- a/packages/search-ui/src/__tests__/palette.test.js
+++ b/packages/search-ui/src/__tests__/palette.test.js
@@ -31,6 +31,10 @@ function makeCtx() {
     // Echoing the key is enough for most assertions. didYouMeanLabel carries a
     // {q} placeholder the layout has to substitute, so it needs a real template.
     t: (k) => (k === 'didYouMeanLabel' ? 'Did you mean {q}?' : k),
+    // Part of the real layout context (buildLayoutContext in search.js); the
+    // composed result surface reads it to draw the active-filter pills.
+    getSelectedFacets: () => ({}),
+    toggleFacet: vi.fn(),
     search: vi.fn()
   };
 }
@@ -168,5 +172,82 @@ describe('palette did-you-mean label contract', () => {
     const results = shadow.getElementById('mp-search-palette-listbox');
     expect(results.querySelector('img')).toBeNull();
     expect(results.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+});
+
+// Ghost gates a post two ways — anyone signed up, or paying readers only — and
+// the palette's row badge has to say which.
+describe('palette gated rows', () => {
+  // Mirrors what normalizeHit hands the layout. `showBadge` is the core's
+  // per-reader decision; `access` is the gate itself.
+  function gatedModel({ visibility, access, showBadge = true }) {
+    return [
+      {
+        id: 'p1',
+        position: 0,
+        url: '/post/',
+        title: 'A post',
+        titleHtml: 'A post',
+        ariaTitle: 'A post',
+        excerptHtml: 'Body teaser',
+        isGated: visibility !== 'public',
+        access,
+        showBadge,
+        visibility,
+        featureImage: null,
+        tags: ['Gardening'],
+        authors: ['Ada Lovelace'],
+        publishedAt: 1700000000000
+      }
+    ];
+  }
+
+  function rowFor(model) {
+    const { layout, shadow } = mountPalette();
+    layout.renderResults(model, { found: 1, query: 'composting' });
+    return shadow.querySelector('.mp-search-palette-row-post');
+  }
+
+  // makeCtx().t echoes the key, so the keys themselves are the assertion.
+  it('labels a free-member row distinctly from a paid one', () => {
+    const free = rowFor(gatedModel({ visibility: 'members', access: 'members' }))
+      .querySelector('.mp-search-palette-badge');
+    expect(free.classList.contains('mp-search-palette-badge-members')).toBe(true);
+    expect(free.textContent).toBe('membersLabel');
+    expect(free.getAttribute('aria-label')).toBe('ariaMembersLabel');
+
+    const paid = rowFor(gatedModel({ visibility: 'paid', access: 'paid' }))
+      .querySelector('.mp-search-palette-badge');
+    expect(paid.classList.contains('mp-search-palette-badge-paid')).toBe(true);
+    expect(paid.textContent).toBe('paidLabel');
+    expect(paid.getAttribute('aria-label')).toBe('ariaPaidLabel');
+  });
+
+  it('badges a tier-gated row as paid', () => {
+    const badge = rowFor(gatedModel({ visibility: 'tiers', access: 'paid' }))
+      .querySelector('.mp-search-palette-badge');
+    expect(badge.classList.contains('mp-search-palette-badge-paid')).toBe(true);
+  });
+
+  // Same contract the modal layout offers, so theme code can style a gate or
+  // route the click to a membership flow whichever layout is in use.
+  it('exposes the raw visibility on the row', () => {
+    const row = rowFor(gatedModel({ visibility: 'tiers', access: 'paid' }));
+    expect(row.getAttribute('data-gated')).toBe('tiers');
+    expect(row.classList.contains('mp-search-result-gated')).toBe(true);
+  });
+
+  it('drops the badge for a reader who can already open the post', () => {
+    const row = rowFor(gatedModel({ visibility: 'members', access: 'members', showBadge: false }));
+    expect(row.querySelector('.mp-search-palette-badge')).toBeNull();
+    // The gate itself is still exposed for theme code.
+    expect(row.getAttribute('data-gated')).toBe('members');
+  });
+
+  it('leaves a public row unbadged and unmarked', () => {
+    const row = rowFor(gatedModel({ visibility: 'public', access: 'public', showBadge: false }));
+    expect(row.querySelector('.mp-search-palette-badge')).toBeNull();
+    expect(row.hasAttribute('data-gated')).toBe(false);
+    expect(row.classList.contains('mp-search-result-gated')).toBe(false);
   });
 });

--- a/packages/search-ui/src/layouts/discovery.css
+++ b/packages/search-ui/src/layouts/discovery.css
@@ -534,20 +534,26 @@
   white-space: nowrap;
 }
 
-/* Members badge — mirrors the shipped .mp-search-gated-badge styling. */
+/* Gated badge — mirrors the shipped .mp-search-gated-badge styling. Quiet for
+   the free-member gate, accent for the paid one, so the two read as a pair. */
 .mp-search-discovery .mp-search-gated-badge {
   display: inline-flex;
   align-items: center;
   gap: calc(0.25 * var(--mp-rem));
   padding: calc(0.125 * var(--mp-rem)) calc(0.4375 * var(--mp-rem));
   border-radius: calc(0.5 * var(--mp-rem));
-  background: color-mix(in srgb, var(--accent-color) 15%, transparent);
-  color: color-mix(in srgb, var(--accent-color) 85%, var(--color-text));
+  background: var(--color-surface-hover);
+  color: var(--color-text-secondary);
   font-size: calc(0.6875 * var(--mp-rem));
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
   white-space: nowrap;
+}
+
+.mp-search-discovery .mp-search-gated-badge-paid {
+  background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 85%, var(--color-text));
 }
 
 .mp-search-discovery-dot {

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -56,11 +56,26 @@ export default function createDiscoveryLayout(ctx) {
     ];
   }
 
-  // The gated members badge, mirroring the shared modal markup. Both strings
-  // come through ctx.t so they stay translatable.
-  function gatedBadge() {
-    return `<span class="${P}-gated-badge" aria-label="${esc(ctx.t('ariaMembersLabel'))}">`
-      + `<span aria-hidden="true">🔒</span> ${esc(ctx.t('membersLabel'))}</span>`;
+  // The gated badge, mirroring the shared modal markup. `access` is the core's
+  // accessLevel value ('members' or 'paid'); both labels come through ctx.t so
+  // they stay translatable.
+  function gatedBadge(access) {
+    const isPaid = access === 'paid';
+    const label = esc(ctx.t(isPaid ? 'paidLabel' : 'membersLabel'));
+    const ariaLabel = esc(ctx.t(isPaid ? 'ariaPaidLabel' : 'ariaMembersLabel'));
+    return `<span class="${P}-gated-badge ${P}-gated-badge-${access}" aria-label="${ariaLabel}">`
+      + `<span aria-hidden="true">🔒</span> ${label}</span>`;
+  }
+
+  // The raw Ghost visibility, exposed on the card and the read-post link so a
+  // theme can style a gate or route the click to a membership flow — the same
+  // contract the modal layout offers.
+  function gatedClass(m) {
+    return m.isGated ? ` ${P}-result-gated` : '';
+  }
+
+  function gatedAttr(m) {
+    return m.isGated ? ` data-gated="${esc(m.visibility)}"` : '';
   }
 
   // The spelling-correction prompt offered under the empty message. Both halves
@@ -178,7 +193,7 @@ export default function createDiscoveryLayout(ctx) {
     }
     const dateStr = formatDate(m.publishedAt);
     if (dateStr) byline.push(`<span>${esc(dateStr)}</span>`);
-    if (m.isGated) byline.push(gatedBadge());
+    if (m.showBadge) byline.push(gatedBadge(m.access));
     if (byline.length) {
       parts.push(
         `<div class="${P}-discovery-preview-byline">`
@@ -188,10 +203,13 @@ export default function createDiscoveryLayout(ctx) {
     }
 
     // Gated notice — never render a protected body; only the teaser/excerpt is
-    // present in the index for non-public posts.
+    // present in the index for non-public posts. Shown for every gated post,
+    // reader or not: it explains why the preview is short, which is a property
+    // of the indexed document rather than of who is reading.
     if (m.isGated) {
+      const notice = ctx.t(m.access === 'paid' ? 'discoveryPaidNotice' : 'discoveryGatedNotice');
       parts.push(
-        `<div class="${P}-discovery-gated-notice" role="note">${esc(ctx.t('discoveryGatedNotice'))}</div>`
+        `<div class="${P}-discovery-gated-notice" role="note">${esc(notice)}</div>`
       );
     }
 
@@ -212,8 +230,8 @@ export default function createDiscoveryLayout(ctx) {
     // delegated click handler (bindEvents) emits the click analytics event.
     if (m.url && m.url !== '#') {
       parts.push(
-        `<a href="${esc(m.url)}" class="${P}-result-link ${P}-discovery-open" `
-        + `data-result-id="${esc(m.id)}" data-result-position="${m.position}" rel="noopener">`
+        `<a href="${esc(m.url)}" class="${P}-result-link ${P}-discovery-open${gatedClass(m)}" `
+        + `data-result-id="${esc(m.id)}" data-result-position="${m.position}"${gatedAttr(m)} rel="noopener">`
         + `${esc(ctx.t('readPostLabel'))} <span aria-hidden="true">→</span></a>`
       );
     }
@@ -601,13 +619,13 @@ export default function createDiscoveryLayout(ctx) {
           }
           const dateStr = formatDate(m.publishedAt);
           if (dateStr) metaParts.push(`<span>${esc(dateStr)}</span>`);
-          if (m.isGated) metaParts.push(gatedBadge());
+          if (m.showBadge) metaParts.push(gatedBadge(m.access));
           const metaHtml = metaParts.join(`<span class="${P}-discovery-dot" aria-hidden="true">·</span>`);
 
           return (
-            `<div class="${P}-discovery-card" id="${P}-discovery-opt-${m.position}" role="option" `
+            `<div class="${P}-discovery-card${gatedClass(m)}" id="${P}-discovery-opt-${m.position}" role="option" `
             + `aria-selected="false" data-index="${m.position}" `
-            + `data-result-id="${esc(m.id)}" data-result-position="${m.position}" `
+            + `data-result-id="${esc(m.id)}" data-result-position="${m.position}"${gatedAttr(m)} `
             + `aria-label="${m.ariaTitle}">`
             + `<p class="${P}-discovery-card-title">${m.titleHtml}</p>`
             + (m.excerptHtml ? `<p class="${P}-discovery-card-excerpt">${m.excerptHtml}</p>` : '')

--- a/packages/search-ui/src/layouts/palette.css
+++ b/packages/search-ui/src/layouts/palette.css
@@ -397,7 +397,8 @@
   color: white;
 }
 
-/* Members badge — accent tint (mirrors the modal's gated badge intent) */
+/* Gated badge — quiet for the free-member gate, accent for the paid one
+   (mirrors the modal's gated badge intent) */
 .mp-search-palette .mp-search-palette-badge {
   padding: calc(0.0625 * var(--mp-rem)) calc(0.375 * var(--mp-rem));
   border-radius: calc(0.5 * var(--mp-rem));
@@ -405,9 +406,15 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-border);
+}
+
+.mp-search-palette .mp-search-palette-badge-paid {
   color: color-mix(in srgb, var(--accent-color) 85%, var(--color-text));
   background: color-mix(in srgb, var(--accent-color) 15%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 30%, transparent);
 }
 
 /* Enter affordance only on the active post row */

--- a/packages/search-ui/src/layouts/palette.js
+++ b/packages/search-ui/src/layouts/palette.js
@@ -291,17 +291,22 @@ export default function createPaletteLayout(ctx) {
     if (tag) metaParts.push(`<span class="${L}-meta-chip">${ctx.escapeHtmlAttr(tag)}</span>`);
     if (date) metaParts.push(`<span class="${L}-meta-date">${ctx.escapeHtmlAttr(date)}</span>`);
 
-    const badge = m.isGated
-      ? `<span class="${L}-badge" aria-label="${ctx.escapeHtmlAttr(ctx.t('ariaMembersLabel'))}">${ctx.escapeHtmlAttr(ctx.t('membersLabel'))}</span>`
+    // One badge per gate: any signed-up reader, or paying readers only. Both
+    // labels come through ctx.t so a publisher can use their own words.
+    const isPaid = m.access === 'paid';
+    const badge = m.showBadge
+      ? `<span class="${L}-badge ${L}-badge-${m.access}" `
+        + `aria-label="${ctx.escapeHtmlAttr(ctx.t(isPaid ? 'ariaPaidLabel' : 'ariaMembersLabel'))}">`
+        + `${ctx.escapeHtmlAttr(ctx.t(isPaid ? 'paidLabel' : 'membersLabel'))}</span>`
       : '';
 
     const position = Number.isNaN(Number(m.position)) ? '' : Number(m.position);
 
     return `
-      <a href="${ctx.escapeHtmlAttr(m.url)}" class="${L}-row ${L}-row-post ${P}-result-link"
+      <a href="${ctx.escapeHtmlAttr(m.url)}" class="${L}-row ${L}-row-post ${P}-result-link${m.isGated ? ` ${P}-result-gated` : ''}"
          id="${L}-row-${idx}" role="option" aria-selected="false"
          data-index="${idx}" data-result-id="${ctx.escapeHtmlAttr(m.id)}"
-         data-result-position="${position}" aria-label="${m.ariaTitle}">
+         data-result-position="${position}"${m.isGated ? ` data-gated="${ctx.escapeHtmlAttr(m.visibility)}"` : ''} aria-label="${m.ariaTitle}">
         <span class="${L}-row-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
                stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -271,6 +271,13 @@ import Typesense from 'typesense';
             this.fetchedSuggestions = [];
             this.suggestionsFetched = false;
 
+            // The reader's own access level, resolved once from Ghost (see
+            // resolveReaderAccess). 'unknown' until it lands — and permanently
+            // when the lookup is off or unavailable — which badges every gated
+            // result, the behaviour of a widget that never asked.
+            this.readerAccess = 'unknown';
+            this.readerAccessPromise = null;
+
             // Default English translations
             this.defaultI18n = {
                 searchPlaceholder: 'Search for anything',
@@ -299,8 +306,14 @@ import Typesense from 'typesense';
                 // control that collapses it again.
                 facetShowMoreLabel: 'Show more',
                 facetShowLessLabel: 'Show less',
-                membersLabel: 'Members only',
+                // Gated-result badges. Ghost has two kinds of gate — anyone
+                // signed up, and paying readers only — so each gets its own
+                // label, overridable by publishers who use their own words for
+                // a paying reader ('supporters', 'patrons', …).
+                membersLabel: 'Members',
                 ariaMembersLabel: 'Members-only content',
+                paidLabel: 'Paid members',
+                ariaPaidLabel: 'Paid-members-only content',
                 untitledPost: 'Untitled',
 
                 // Relative dates for the refined result rows. {n} is substituted.
@@ -350,7 +363,8 @@ import Typesense from 'typesense';
                 discoveryEmptyTitle: 'Search the archive',
                 discoveryEmptyHint: 'Start typing to explore posts. Use ↑ ↓ to move and ↵ to open.',
                 discoveryNoFilters: 'No filters available.',
-                discoveryGatedNotice: 'This post is available to members. Only the public teaser is shown here.'
+                discoveryGatedNotice: 'This post is available to members. Only the public teaser is shown here.',
+                discoveryPaidNotice: 'This post is available to paid members. Only the public teaser is shown here.'
             };
         }
 
@@ -392,7 +406,12 @@ import Typesense from 'typesense';
                 // Overall UI layout: 'modal' (default, the built-in centered
                 // modal) or an alternative layout loaded on demand ('palette',
                 // 'discovery'). Unknown values fall back to 'modal'.
-                uiStyle: ALT_LAYOUTS.includes(defaultConfig.uiStyle) ? defaultConfig.uiStyle : 'modal'
+                uiStyle: ALT_LAYOUTS.includes(defaultConfig.uiStyle) ? defaultConfig.uiStyle : 'modal',
+                // Opt in to reading the reader's own membership from Ghost, so a
+                // badge is only shown for content they actually cannot open.
+                // Off by default: the widget is also embedded on sites that have
+                // no Ghost member endpoint to ask.
+                memberAwareBadges: defaultConfig.memberAwareBadges === true
             };
 
             if (!this.config.typesenseNodes || !this.config.typesenseApiKey || !this.config.collectionName) {
@@ -407,6 +426,12 @@ import Typesense from 'typesense';
 
             // Store locale for future use
             this.locale = this.config.locale || 'en';
+
+            // Start the membership lookup now rather than on first search, so it
+            // has almost certainly landed by the time a reader types. Nothing
+            // waits on it: until it resolves, gated results simply keep their
+            // badge.
+            this.resolveReaderAccess();
 
             // init() is async (an alternative layout lazily loads its chunk);
             // expose the promise so openModal can wait for the surface to be
@@ -652,6 +677,11 @@ import Typesense from 'typesense';
                 ariaTitle: this.escapeHtmlAttr(String(titleHtml).replace(/<[^>]*>/g, '')),
                 excerptHtml,
                 isGated,
+                // Which gate this result sits behind, and whether this reader
+                // still needs telling about it. Resolved here so no layout has
+                // to reimplement the rule.
+                access: this.accessLevel(doc.visibility),
+                showBadge: this.needsBadge(doc.visibility),
                 visibility: doc.visibility || 'public',
                 featureImage: doc.feature_image || null,
                 tags: Array.isArray(doc.tags) ? doc.tags : [],
@@ -1424,9 +1454,14 @@ import Typesense from 'typesense';
                         : (hit.document.url || '#');
 
                     // A non-public (members-only / paid) result, surfaced via
-                    // the redacted index documents. Flagged so it can be styled
-                    // and routed to a membership flow.
+                    // the redacted index documents. The raw visibility stays on
+                    // the link so a theme can style it or route the click to a
+                    // membership flow; `badgeAccess` is the narrower question of
+                    // what to show this reader.
                     const isGated = !!hit.document.visibility && hit.document.visibility !== 'public';
+                    const badgeAccess = this.needsBadge(hit.document.visibility)
+                        ? this.accessLevel(hit.document.visibility)
+                        : null;
 
                     // The link wrapper (class + data attributes + aria-label) is
                     // shared by both templates, so keyboard navigation, click
@@ -1440,8 +1475,8 @@ import Typesense from 'typesense';
                             ${isGated ? `data-gated="${this.escapeHtmlAttr(hit.document.visibility)}"` : ''}
                             aria-label="${title.replace(/<[^>]*>/g, '')}">
                             ${this.config.template === 'grid'
-                                ? this.renderGridCard(hit, title, excerpt, isGated)
-                                : this.renderListItem(hit, title, excerpt, isGated)}
+                                ? this.renderGridCard(hit, title, excerpt, badgeAccess)
+                                : this.renderListItem(hit, title, excerpt, badgeAccess)}
                         </a>
                     `;
                 }).join('');
@@ -2069,11 +2104,79 @@ import Typesense from 'typesense';
             }
         }
 
-        // A small lock badge shown on gated (members-only / paid) results.
-        gatedBadge(isGated) {
-            if (!isGated) return '';
-            return `<span class="${CSS_PREFIX}-gated-badge" aria-label="${this.t('ariaMembersLabel')}">
-                        <span aria-hidden="true">🔒</span> ${this.t('membersLabel')}
+        // Ghost's post visibility, reduced to the gate a reader runs into:
+        // 'public' (none), 'members' (any signed-up reader), or 'paid'.
+        //
+        // 'tiers' counts as paid. Ghost filters a tiers post's tier list down to
+        // paid tiers when it serialises the post, so tier-gated content is never
+        // reachable on a free account. Anything else unrecognised falls back to
+        // 'members', which is the weaker of the two claims.
+        accessLevel(visibility) {
+            const value = visibility || 'public';
+            if (value === 'public') return 'public';
+            if (value === 'paid' || value === 'tiers') return 'paid';
+            return 'members';
+        }
+
+        // Whether this reader still needs the badge on a gated result.
+        //
+        // Only suppressed where access is certain: a signed-in reader of any
+        // kind can open a members post, and a paying reader can open a paid
+        // one. A 'tiers' post names specific paid tiers that the index does not
+        // record, so it stays badged even for a paying reader rather than
+        // promising access we cannot verify.
+        needsBadge(visibility) {
+            const access = this.accessLevel(visibility);
+            if (access === 'public') return false;
+
+            const signedIn = this.readerAccess === 'free' || this.readerAccess === 'paid';
+            if (signedIn && access === 'members') return false;
+            if (this.readerAccess === 'paid' && visibility === 'paid') return false;
+            return true;
+        }
+
+        // Ask Ghost who is reading, once per page. Same-origin and cookie-authed:
+        // 204 means signed out, a body means signed in, and `paid` there already
+        // folds in comped members. Every other outcome — the flag off, a site
+        // without the endpoint, an offline reader — leaves 'unknown', which
+        // badges everything.
+        //
+        // Deliberately never awaited by a render path: badges reflect whatever
+        // has resolved by the time a query is typed, and the request is fired at
+        // init so that is almost always the real answer.
+        resolveReaderAccess() {
+            if (!this.config.memberAwareBadges) return Promise.resolve('unknown');
+            if (this.readerAccessPromise) return this.readerAccessPromise;
+
+            this.readerAccessPromise = fetch('/members/api/member', {
+                credentials: 'same-origin',
+                cache: 'no-store',
+                headers: { Accept: 'application/json' }
+            })
+                .then(async (response) => {
+                    if (response.status === 204) return 'anonymous';
+                    if (!response.ok) return 'unknown';
+                    const member = await response.json();
+                    return member && member.paid ? 'paid' : 'free';
+                })
+                .catch(() => 'unknown')
+                .then((access) => {
+                    this.readerAccess = access;
+                    return access;
+                });
+
+            return this.readerAccessPromise;
+        }
+
+        // A small lock badge shown on gated results. `access` is an accessLevel()
+        // value; 'public' (or nothing) renders no badge.
+        gatedBadge(access) {
+            if (!access || access === 'public') return '';
+            const isPaid = access === 'paid';
+            const label = this.escapeHtmlAttr(this.t(isPaid ? 'paidLabel' : 'membersLabel'));
+            const ariaLabel = this.escapeHtmlAttr(this.t(isPaid ? 'ariaPaidLabel' : 'ariaMembersLabel'));
+            return `<span class="${CSS_PREFIX}-gated-badge ${CSS_PREFIX}-gated-badge-${access}" aria-label="${ariaLabel}">
+                        <span aria-hidden="true">🔒</span> ${label}
                     </span>`;
         }
 
@@ -2100,35 +2203,35 @@ import Typesense from 'typesense';
         // Two call signatures are supported, distinguished at runtime by the
         // type of the first argument:
         //
-        //   renderListItem(title: string, excerpt?: string, isGated?: boolean)
+        //   renderListItem(title: string, excerpt?: string, access?: string)
         //     — the simple title+excerpt row. Used by the unit tests, which
         //       assert on this stable shape.
-        //   renderListItem(hit: object, title: string, excerpt: string, isGated: boolean)
+        //   renderListItem(hit: object, title: string, excerpt: string, access: string)
         //     — the rich row. `hit` is the Typesense hit (its `.document`
         //       supplies feature_image/tags/authors/etc.); `title`/`excerpt`
-        //       are the highlighted HTML. `isGated` arrives as the 4th argument
-        //       (read via `arguments[3]`) so the two signatures can share the
-        //       same three named parameters.
+        //       are the highlighted HTML. `access` is an accessLevel() value and
+        //       arrives as the 4th argument (read via `arguments[3]`) so the two
+        //       signatures can share the same three named parameters.
         //
         // Prefer calling the rich signature explicitly with all four arguments.
-        renderListItem(hitOrTitle, excerptOrUndefined, isGatedArg) {
-            // Legacy/string-call signature (tests): (title, excerpt, isGated)
+        renderListItem(hitOrTitle, excerptOrUndefined, accessArg) {
+            // Legacy/string-call signature (tests): (title, excerpt, access)
             if (typeof hitOrTitle === 'string') {
                 const title = hitOrTitle;
                 const excerpt = excerptOrUndefined || '';
                 return `
                     <article class="${CSS_PREFIX}-result-item" role="article">
-                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(isGatedArg)}</h3>
+                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(accessArg)}</h3>
                         <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
                     </article>
                 `;
             }
 
-            // Rich-call signature: (hit, title, excerpt, isGated)
+            // Rich-call signature: (hit, title, excerpt, access)
             const hit = hitOrTitle;
             const title = excerptOrUndefined;
-            const excerpt = isGatedArg;
-            const isGated = arguments[3];
+            const excerpt = accessArg;
+            const access = arguments[3];
             const doc = hit.document || {};
 
             const featureImage = doc.feature_image;
@@ -2152,7 +2255,7 @@ import Typesense from 'typesense';
                 <article class="${CSS_PREFIX}-result-item ${CSS_PREFIX}-row" role="article">
                     ${thumb}
                     <div class="${CSS_PREFIX}-row-body">
-                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(isGated)}</h3>
+                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(access)}</h3>
                         <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
                         ${meta}
                     </div>
@@ -2164,7 +2267,7 @@ import Typesense from 'typesense';
         // image is decorative (the link already carries the title via
         // aria-label); when a post has no feature_image a styled placeholder is
         // shown instead of a broken image.
-        renderGridCard(hit, title, excerpt, isGated) {
+        renderGridCard(hit, title, excerpt, access) {
             const featureImage = hit.document.feature_image;
             const imageHtml = featureImage
                 ? `<img class="${CSS_PREFIX}-card-image" src="${this.escapeHtmlAttr(featureImage)}" alt="" loading="lazy" />`
@@ -2181,7 +2284,7 @@ import Typesense from 'typesense';
                 <article class="${CSS_PREFIX}-result-item ${CSS_PREFIX}-card" role="article">
                     ${imageHtml}
                     <div class="${CSS_PREFIX}-card-body">
-                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(isGated)}</h3>
+                        <h3 class="${CSS_PREFIX}-result-title" role="heading" aria-level="3">${title}${this.gatedBadge(access)}</h3>
                         <p class="${CSS_PREFIX}-result-excerpt" aria-label="${this.t('ariaArticleExcerpt')}">${excerpt}</p>
                         ${tagsHtml}
                     </div>

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -218,6 +218,11 @@ import Typesense from 'typesense';
     const DEFAULT_FACET_LIMIT = 10;
     const FACET_EXPANSION_STEP = 40;
 
+    // Ghost's own member-session endpoint, relative to the origin root. A
+    // subdirectory install or a path-rewriting proxy overrides it via
+    // `memberEndpoint`.
+    const DEFAULT_MEMBER_ENDPOINT = '/members/api/member';
+
     // Web Component Definition
     class MagicPagesSearchElement extends HTMLElement {
         constructor() {
@@ -411,7 +416,14 @@ import Typesense from 'typesense';
                 // badge is only shown for content they actually cannot open.
                 // Off by default: the widget is also embedded on sites that have
                 // no Ghost member endpoint to ask.
-                memberAwareBadges: defaultConfig.memberAwareBadges === true
+                memberAwareBadges: defaultConfig.memberAwareBadges === true,
+                // Where that lookup goes. The default is Ghost's own path at the
+                // origin root; a subdirectory install or a path-rewriting proxy
+                // needs its own prefix, or the lookup 404s and every gated
+                // result keeps its badge.
+                memberEndpoint: typeof defaultConfig.memberEndpoint === 'string' && defaultConfig.memberEndpoint.trim()
+                    ? defaultConfig.memberEndpoint.trim()
+                    : DEFAULT_MEMBER_ENDPOINT
             };
 
             if (!this.config.typesenseNodes || !this.config.typesenseApiKey || !this.config.collectionName) {
@@ -2135,11 +2147,11 @@ import Typesense from 'typesense';
             return true;
         }
 
-        // Ask Ghost who is reading, once per page. Same-origin and cookie-authed:
-        // 204 means signed out, a body means signed in, and `paid` there already
-        // folds in comped members. Every other outcome — the flag off, a site
-        // without the endpoint, an offline reader — leaves 'unknown', which
-        // badges everything.
+        // Ask Ghost who is reading, once per page, at `memberEndpoint`.
+        // Same-origin and cookie-authed: 204 means signed out, a body means
+        // signed in, and `paid` there already folds in comped members. Every
+        // other outcome — the flag off, a site without the endpoint, an offline
+        // reader — leaves 'unknown', which badges everything.
         //
         // Deliberately never awaited by a render path: badges reflect whatever
         // has resolved by the time a query is typed, and the request is fired at
@@ -2148,7 +2160,7 @@ import Typesense from 'typesense';
             if (!this.config.memberAwareBadges) return Promise.resolve('unknown');
             if (this.readerAccessPromise) return this.readerAccessPromise;
 
-            this.readerAccessPromise = fetch('/members/api/member', {
+            this.readerAccessPromise = fetch(this.config.memberEndpoint || DEFAULT_MEMBER_ENDPOINT, {
                 credentials: 'same-origin',
                 cache: 'no-store',
                 headers: { Accept: 'application/json' }

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -732,7 +732,7 @@ import Typesense from 'typesense';
                 collapseFacet: (field) => this.collapseFacet(field),
                 setFacetFilter: () => {},
                 search: (q) => this.handleSearch(q),
-                requery: () => this.rerunQueryForFacets(),
+                requery: () => this.rerunQuery(),
                 trackSearch: (q, c) => this.trackSearch(q, c),
                 trackClick: (id, pos) => this.trackClick(id, pos),
                 emitClick: (id, pos) => this.trackClick(id, pos),
@@ -2068,7 +2068,7 @@ import Typesense from 'typesense';
                 if (clearBtn) {
                     e.preventDefault();
                     this.selectedFacets = {};
-                    this.rerunQueryForFacets();
+                    this.rerunQuery();
                     return;
                 }
 
@@ -2081,7 +2081,7 @@ import Typesense from 'typesense';
                     else this.expandFacet(field);
                     // The wider (or narrower) list comes from the response, so
                     // the current query is re-run for it.
-                    this.rerunQueryForFacets();
+                    this.rerunQuery();
                     return;
                 }
 
@@ -2103,13 +2103,15 @@ import Typesense from 'typesense';
                     set.add(value);
                 }
 
-                this.rerunQueryForFacets();
+                this.rerunQuery();
             });
         }
 
-        // Re-run the active query after a facet change, using the live input
-        // value (falling back to the last searched query).
-        rerunQueryForFacets() {
+        // Re-run the active query, using the live input value (falling back to
+        // the last searched query). Called when something the results depend on
+        // changes underneath them — a facet selection, or the reader's own
+        // membership arriving after a render.
+        rerunQuery() {
             const query = this.searchInput?.value?.trim() || this.lastQuery;
             if (query) {
                 this.handleSearch(query);
@@ -2153,9 +2155,11 @@ import Typesense from 'typesense';
         // other outcome — the flag off, a site without the endpoint, an offline
         // reader — leaves 'unknown', which badges everything.
         //
-        // Deliberately never awaited by a render path: badges reflect whatever
-        // has resolved by the time a query is typed, and the request is fired at
-        // init so that is almost always the real answer.
+        // Deliberately never awaited by a render path, so search latency never
+        // depends on it. The request is fired at init, so by the time a reader
+        // has opened search and typed it has almost always landed; if it has
+        // not, results render badged for an unknown reader and the query is
+        // re-run once when the answer arrives.
         resolveReaderAccess() {
             if (!this.config.memberAwareBadges) return Promise.resolve('unknown');
             if (this.readerAccessPromise) return this.readerAccessPromise;
@@ -2174,6 +2178,14 @@ import Typesense from 'typesense';
                 .catch(() => 'unknown')
                 .then((access) => {
                     this.readerAccess = access;
+                    // Anything already rendered was badged for an unknown
+                    // reader. Only a signed-in reader changes any of those
+                    // badges — 'anonymous' and 'unknown' badge identically — so
+                    // only then is a re-render worth a request. At init there is
+                    // nothing on screen and rerunQuery is a no-op, which is the
+                    // usual case: the lookup lands long before a reader has
+                    // opened search and typed.
+                    if (access === 'free' || access === 'paid') this.rerunQuery();
                     return access;
                 });
 

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -590,7 +590,9 @@
     opacity: 0.5;
 }
 
-/* Members-only / paid result badge */
+/* Gated result badge. The free-member badge stays quiet; the paid badge carries
+   the accent, so a reader can tell the two gates apart at a glance. Both derive
+   from the theme tokens, so light and dark follow with no extra rules. */
 .mp-search-gated-badge {
     display: inline-flex;
     align-items: center;
@@ -605,6 +607,12 @@
     letter-spacing: 0.02em;
     vertical-align: middle;
     white-space: nowrap;
+}
+
+.mp-search-gated-badge-paid {
+    background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+    color: color-mix(in srgb, var(--accent-color) 85%, var(--color-text));
+    font-weight: 600;
 }
 
 /* Grid (card) layout */


### PR DESCRIPTION
Every non-public result carried the same **"Members only"** badge. On any site that sells a subscription that is wrong on a good share of them: Ghost gates a post either to anyone who signed up or to paying readers only, and a free subscriber is a "member" as far as they are concerned — so they read the badge, click, and hit a paywall.

## Badging by gate

| Ghost `visibility` | Badge | Meaning |
| --- | --- | --- |
| `public` | none | anyone can read it |
| `members` | **Members** | any signed-up reader, free included |
| `paid` | **Paid members** | paying readers only |
| `tiers` | **Paid members** | specific paid tiers only |

`tiers` counts as paid because Ghost only ever tier-restricts to *paid* tiers — its post serialiser filters a tiers post's tier list to `type === 'paid'`, so tier-gated content is never reachable on a free account.

The free badge stays quiet and the paid one carries the site's accent colour in all three layouts, so the two read as a pair rather than as one badge with two spellings.

**No reindex needed.** `buildRedactedPost()` already stored Ghost's exact `visibility`, and the widget already requested the field. It was collapsing it to a boolean in two separate places; both now go through one `accessLevel()`.

## Publisher terminology

Both labels go through i18n, so a site that calls its paying readers something of its own says so in config:

```js
i18n: {
  membersLabel: 'Subscribers',
  paidLabel: 'Supporters',
  ariaPaidLabel: 'Content for supporters only'
}
```

`paidLabel` / `ariaPaidLabel` join the existing members keys, and the discovery preview notice gains a `discoveryPaidNotice` variant.

## `memberAwareBadges` (opt-in)

Naming the gate helps, but a reader still has to read the badge to work out a post is not for them. With this flag the widget resolves the reader once from Ghost's own `/members/api/member` (same-origin, cookie-authed) and drops the badge from anything they can already open:

| Post | signed out | free member | paying member |
| --- | --- | --- | --- |
| `members` | badge | — | — |
| `paid` | badge | badge | — |
| `tiers` | badge | badge | **badge** |

A `tiers` post keeps its badge even for a paying reader: it names specific paid tiers, and the index does not record which, so the widget will not promise access it cannot verify.

**Off by default** — the widget is also embedded on sites with no Ghost member endpoint to ask. The request is fired at init and never awaited by a render path, and every failure (endpoint missing, reader offline, response not back yet) leaves `readerAccess` at `'unknown'`, which badges everything — exactly the behaviour without the flag. Nothing is ever wrongly unbadged.

## Incidental fixes

- **`data-gated` in every layout.** `mp-search-result-gated` and `data-gated="<visibility>"` are documented as the hook for styling a gated result or routing its click into a membership flow, but only the modal layout emitted them — a site on the palette or discovery layout had nothing to hook. Both now appear on the palette row, the discovery card, and the discovery "Read post" link, so `[data-gated="paid"], [data-gated="tiers"]` selects the paid gate whichever layout is in use. They are independent of the badge: when `memberAwareBadges` suppresses a badge, the gate stays on the element.
- **Unescaped ARIA label.** The modal's gated badge interpolated `t('ariaMembersLabel')` straight into an attribute, unlike the same badge in the palette and discovery layouts. All three now go through the escaper.
- **`example.config.json` dropped `visibility`.** It supplies its own `fields` array, and only *required* fields are backfilled — so anyone starting from the example got a collection where `visibility` (which the badges read), `tags.name`, and `tags.slug` were undeclared and not facetable. The example now lists them, and `@magicpages/ghost-typesense-config`'s README documents the backfill rule instead of a stale field list.

## Behaviour change

`membersLabel` now defaults to **"Members"**, not "Members only" — it is no longer the label for every gate, so a name reading "and nothing more" was misleading beside the new paid badge. An existing override keeps working and now applies only to `visibility: members`; sites that had overridden it to cover all gated posts will want to set `paidLabel` too.

## Testing

`lint`, `typecheck`, `test`, and `build` green across all workspaces. search-ui goes from 166 to 202 tests, covering the `accessLevel` mapping (including `tiers` and unrecognised values), `needsBadge` across the full reader table, badge label/class/ARIA per gate, a translation containing markup rendering as text, and the member lookup for 204 / free / paying / network error / 404 / flag-off-means-no-request.

Verified by hand in the playground across modal (list + grid), palette, and discovery, in light and dark: badges correct per gate, `data-gated` present in every layout, the discovery notice matching its gate, the palette at 380px with no overflow, the reader table stepped signed-out → free → paying, and zero requests to `/members/api/member` with the flag off.

The playground gains a `tiers` fixture, a dev-server stub for the member endpoint, and a "Signed-in reader" control, so all of this stays checkable without a Ghost install.

Version bumped to 2.3.0 across the workspace.

## Summary by Sourcery

Make gated search results accurately communicate their access requirements and optionally tailor badges to the current reader.

New Features:
- Distinguish member-only, paid-member, and tier-restricted search results with separate badges, styling, and configurable translations.
- Add optional reader-aware badging that hides badges for content the authenticated reader can confidently access.
- Expose gated-result metadata and styling hooks consistently across modal, palette, and discovery layouts.

Bug Fixes:
- Escape translated ARIA labels in gated badges to prevent markup or attribute injection.
- Include visibility and related tag fields in the example index configuration and clarify optional-field backfill behavior.

Enhancements:
- Preserve Ghost visibility values through gated-content indexing and centralize access-level handling in the search UI.
- Add separate paid-gate discovery notices and update the default members badge terminology.

Build:
- Bump all workspace packages to version 2.3.0.

Documentation:
- Document gate-specific badges, reader-aware configuration, member endpoint customization, and cross-layout gated-result hooks.

Tests:
- Expand search UI and core coverage for visibility mapping, reader access resolution, badge rendering, escaping, and gated metadata across layouts.

Chores:
- Extend the playground with tier fixtures, member-session simulation, and signed-in reader controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional member-aware gated-content badges, distinguishing members-only and paid content.
  * Added reader membership detection for anonymous, free, and paid access states.
  * Added visibility metadata to gated search results for styling and integrations.
  * Added playground controls for testing membership states and tier-restricted content.

* **Bug Fixes**
  * Improved gated-content redaction and accessibility label escaping.
  * Updated badge styling and labels for clearer access distinctions.

* **Documentation**
  * Updated configuration and search documentation, including field-list guidance and new badge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->