### PR TITLE
fix(search-ui): hold focus when a theme focus-traps its open navigation

### DIFF
--- a/packages/search-ui/src/layouts/discovery.css
+++ b/packages/search-ui/src/layouts/discovery.css
@@ -45,6 +45,19 @@
   line-height: 1.5;
   color: var(--color-text);
   -webkit-text-size-adjust: 100%;
+
+  /* The root is a <dialog>: drop the UA chrome. background matters most here —
+     the scrim is a child element, so the UA's opaque canvas would hide the
+     page behind an unstyled slab. */
+  border: 0;
+  margin: 0;
+  max-width: none;
+  max-height: none;
+  background: transparent;
+}
+
+.mp-search-discovery::backdrop {
+  background: transparent;
 }
 
 /* Dark theme overrides (mirrors styles.css .mp-search-dark) */

--- a/packages/search-ui/src/layouts/discovery.js
+++ b/packages/search-ui/src/layouts/discovery.js
@@ -338,7 +338,7 @@ export default function createDiscoveryLayout(ctx) {
 
     buildMarkup() {
       return `
-        <div id="${P}-discovery" class="${P}-discovery ${P}-hidden" role="dialog" aria-modal="true" aria-label="${esc(ctx.t('ariaModalLabel'))}">
+        <dialog id="${P}-discovery" class="${P}-discovery ${P}-hidden" aria-modal="true" aria-label="${esc(ctx.t('ariaModalLabel'))}">
           <div class="${P}-backdrop"></div>
           <div class="${P}-discovery-panel" role="document">
             <div class="${P}-discovery-header">
@@ -358,7 +358,7 @@ export default function createDiscoveryLayout(ctx) {
               <section id="${P}-discovery-preview" class="${P}-discovery-preview" aria-live="polite" aria-label="${esc(ctx.t('discoveryPreviewLabel'))}"></section>
             </div>
           </div>
-        </div>`;
+        </dialog>`;
     },
 
     cacheElements(shadowRoot) {
@@ -382,6 +382,9 @@ export default function createDiscoveryLayout(ctx) {
         refs.panel.addEventListener('mousedown', (e) => {
           if (e.target.classList.contains(`${P}-backdrop`)) ctx.close();
         });
+        // Esc dismisses a modal <dialog> natively; route it back through the
+        // core so lifecycle state follows the surface.
+        refs.panel.addEventListener('close', () => ctx.close());
       }
 
       // Debounced, core-driven search (~80ms).
@@ -475,7 +478,10 @@ export default function createDiscoveryLayout(ctx) {
     },
 
     onOpen() {
-      if (refs.panel) refs.panel.classList.remove(`${P}-hidden`);
+      if (refs.panel) {
+        refs.panel.classList.remove(`${P}-hidden`);
+        ctx.enterTopLayer(refs.panel);
+      }
       // Paint the welcoming initial state if nothing has been typed yet — the
       // seam doesn't render layouts on open, so without this the panes show as
       // bare empty columns.
@@ -483,7 +489,10 @@ export default function createDiscoveryLayout(ctx) {
     },
 
     onClose() {
-      if (refs.panel) refs.panel.classList.add(`${P}-hidden`);
+      if (refs.panel) {
+        ctx.exitTopLayer(refs.panel);
+        refs.panel.classList.add(`${P}-hidden`);
+      }
       if (refs.input) refs.input.value = '';
       if (debounce) { clearTimeout(debounce); debounce = null; }
       model = [];

--- a/packages/search-ui/src/layouts/palette.css
+++ b/packages/search-ui/src/layouts/palette.css
@@ -45,6 +45,23 @@
   line-height: 1.5;
   color: var(--color-text);
   -webkit-text-size-adjust: 100%;
+
+  /* The root is a <dialog>: drop the UA chrome. This rule sets no size of its
+     own and relies on inset, so width/height must stay auto rather than the
+     UA's fit-content, and the scrim is a child element so the UA's opaque
+     canvas background has to go. */
+  border: 0;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  background: transparent;
+}
+
+.mp-search-palette::backdrop {
+  background: transparent;
 }
 
 .mp-search-palette.mp-search-dark {

--- a/packages/search-ui/src/layouts/palette.js
+++ b/packages/search-ui/src/layouts/palette.js
@@ -483,7 +483,7 @@ export default function createPaletteLayout(ctx) {
 
     buildMarkup() {
       return `
-        <div id="${L}" class="${L} ${P}-hidden" role="dialog" aria-modal="true"
+        <dialog id="${L}" class="${L} ${P}-hidden" aria-modal="true"
              aria-label="${ctx.t('ariaModalLabel')}">
           <div class="${P}-backdrop ${L}-backdrop"></div>
           <div class="${L}-panel">
@@ -524,7 +524,7 @@ export default function createPaletteLayout(ctx) {
               <span class="${L}-hint ${L}-status" aria-live="polite"></span>
             </div>
           </div>
-        </div>`;
+        </dialog>`;
     },
 
     cacheElements(shadowRoot) {
@@ -543,6 +543,12 @@ export default function createPaletteLayout(ctx) {
     bindEvents() {
       if (refs.backdrop) {
         refs.backdrop.addEventListener('click', () => ctx.close());
+      }
+
+      // Esc dismisses a modal <dialog> natively; route it back through the
+      // core so lifecycle state follows the surface.
+      if (refs.panel) {
+        refs.panel.addEventListener('close', () => ctx.close());
       }
 
       if (refs.input) {
@@ -615,7 +621,10 @@ export default function createPaletteLayout(ctx) {
     },
 
     onOpen() {
-      if (refs.panel) refs.panel.classList.remove(`${P}-hidden`);
+      if (refs.panel) {
+        refs.panel.classList.remove(`${P}-hidden`);
+        ctx.enterTopLayer(refs.panel);
+      }
       // Refresh recent (another tab may have written it) and show the recent
       // surface if nothing has been typed yet.
       if (!currentQuery.trim()) {
@@ -625,7 +634,10 @@ export default function createPaletteLayout(ctx) {
     },
 
     onClose() {
-      if (refs.panel) refs.panel.classList.add(`${P}-hidden`);
+      if (refs.panel) {
+        ctx.exitTopLayer(refs.panel);
+        refs.panel.classList.add(`${P}-hidden`);
+      }
       if (refs.input) refs.input.value = '';
       currentQuery = '';
       currentModel = [];

--- a/packages/search-ui/src/search.js
+++ b/packages/search-ui/src/search.js
@@ -75,6 +75,39 @@ import Typesense from 'typesense';
         return promise;
     }
 
+    // Promote a surface into the browser's top layer.
+    //
+    // Themes commonly focus-trap an open navigation (the focus-trap library is
+    // widespread). A trap re-focuses its own container whenever focus lands
+    // outside it, and a nav link pointing at Ghost's #/search hash opens our
+    // search without unloading the page — so the trap is still armed and takes
+    // the caret straight back out of our input, leaving a visible but
+    // untypeable modal.
+    //
+    // showModal() makes every element outside the top layer inert, so the
+    // trap's own focus() call becomes a no-op and the caret stays with us. This
+    // neutralises the trap by declaring real modality rather than by patching
+    // or disabling the theme's accessibility code.
+    //
+    // Visibility stays owned by the CSS_PREFIX-hidden class on both paths;
+    // these helpers only add modality, and no-op where <dialog> is unsupported
+    // (Safari < 15.4) or unimplemented (jsdom), which keeps the pre-dialog
+    // behaviour intact.
+    function enterTopLayer(el) {
+        if (!el || typeof el.showModal !== 'function' || el.open) return;
+        try {
+            el.showModal();
+        } catch {
+            // Not connected yet, or already modal via another path. The surface
+            // is visible regardless, so degrade to the non-modal behaviour.
+        }
+    }
+
+    function exitTopLayer(el) {
+        if (!el || typeof el.close !== 'function' || !el.open) return;
+        el.close();
+    }
+
     function cleanupGhostSearch() {
         // Only cleanup after we've initialized
         if (!isInitialized) return;
@@ -737,6 +770,10 @@ import Typesense from 'typesense';
                 trackClick: (id, pos) => this.trackClick(id, pos),
                 emitClick: (id, pos) => this.trackClick(id, pos),
                 close: () => this.closeModal(),
+                // Layouts own their root element, so they promote and demote it
+                // themselves. See enterTopLayer for why this matters.
+                enterTopLayer: (el) => enterTopLayer(el),
+                exitTopLayer: (el) => exitTopLayer(el),
                 log: () => {}
             };
         }
@@ -830,7 +867,7 @@ import Typesense from 'typesense';
             // Create modal HTML
             const modalContainer = document.createElement('div');
             modalContainer.innerHTML = `
-                <div id="${CSS_PREFIX}-modal" class="${CSS_PREFIX}-modal ${CSS_PREFIX}-hidden" role="dialog" aria-modal="true" aria-label="${this.t('ariaModalLabel')}">
+                <dialog id="${CSS_PREFIX}-modal" class="${CSS_PREFIX}-modal ${CSS_PREFIX}-hidden" aria-modal="true" aria-label="${this.t('ariaModalLabel')}">
                     <div class="${CSS_PREFIX}-backdrop"></div>
                     <div class="${CSS_PREFIX}-container">
                         <button class="${CSS_PREFIX}-close" aria-label="${this.t('ariaCloseLabel')}">
@@ -885,7 +922,7 @@ import Typesense from 'typesense';
                             </div>
                         </div>
                     </div>
-                </div>
+                </dialog>
             `;
 
             // Append to shadow DOM
@@ -1003,6 +1040,13 @@ import Typesense from 'typesense';
                     this.closeModal();
                 }
             });
+
+            // A modal <dialog> closes itself on Esc, which would otherwise
+            // leave isModalOpen, the scroll lock and the URL hash out of sync
+            // with a dismissed surface. Routing the native event back through
+            // closeModal() reconciles them; it early-returns when our own Esc
+            // handler already ran, so the two paths can't double-close.
+            this.modal.addEventListener('close', () => this.closeModal());
 
             // Prevent clicks on modal content from closing
             const modalContent = this.shadowRoot.querySelector(`.${CSS_PREFIX}-container`);
@@ -1169,8 +1213,10 @@ import Typesense from 'typesense';
                 this.activeLayout.onOpen();
                 this.activeLayout.focusInput();
             } else if (this.modal) {
-                // Show modal
+                // Show modal. Unhide before entering the top layer: showModal()
+                // on a display:none element has nothing to focus.
                 this.modal.classList.remove(`${CSS_PREFIX}-hidden`);
+                enterTopLayer(this.modal);
                 // Focus search input
                 setTimeout(() => {
                     this.searchInput && this.searchInput.focus();
@@ -1209,6 +1255,7 @@ import Typesense from 'typesense';
             if (this.activeLayout) {
                 this.activeLayout.onClose();
             } else {
+                exitTopLayer(this.modal);
                 this.modal.classList.add(`${CSS_PREFIX}-hidden`);
                 if (this.searchInput) this.searchInput.value = '';
             }

--- a/packages/search-ui/src/styles.css
+++ b/packages/search-ui/src/styles.css
@@ -91,6 +91,23 @@
     padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
     /* Above subscribe button on mobile */
     z-index: 3999999;
+
+    /* The root is a <dialog>, so neutralise the UA chrome it ships with
+       (border, auto margins and a max-width/height that would shrink it away
+       from the full-viewport overlay above). z-index still governs the
+       non-modal fallback path; once showModal() promotes this into the top
+       layer the stacking order is the browser's, not ours, which puts the
+       overlay above Ghost's subscribe button on desktop too. */
+    border: 0;
+    margin: 0;
+    max-width: none;
+    max-height: none;
+}
+
+/* Our own backdrop element provides the scrim, so the top-layer one stays out
+   of the way instead of double-darkening it. */
+.mp-search-modal::backdrop {
+    background: transparent;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
Fixes #93.

Opening the search from a link inside a theme's popup navigation left the panel visible but unusable — the input never held the caret, so readers could not type or paste. Loading `#/search` directly worked, which is what made it look like a search bug rather than a focus one.

## Cause

Themes commonly focus-trap their popup navigation while it is open, and a trap re-focuses its own container whenever focus lands outside it. Its release paths are typically the close button, Escape, or a page load.

A nav link pointing at Ghost's `#/search` magic URL fires none of them: the hash change opens our search without unloading the page, so the trap is still armed. Our surfaces render into the widget's shadow root — same document — so the trap sees the `focusin`, blurs the input and pulls the caret back into the navigation. Every other nav item hides the problem, because a real link unloads the document and takes the trap with it.

Ghost's own search is unaffected because it renders inside an iframe, and focus moving into a nested browsing context dispatches no `focusin` in the parent document.

## Change

Each surface root becomes a `<dialog>` promoted with `showModal()`. The browser makes everything outside the top layer inert, so the trap's own `focus()` call is a no-op and the caret stays put. The trap keeps working as its author intended — nothing patches or disables it.

| File | Change |
| --- | --- |
| `search.js` | `enterTopLayer`/`exitTopLayer` helpers, modal root, `openModal`/`closeModal` wiring, helpers on the layout ctx, native `close` listener |
| `layouts/discovery.js`, `layouts/palette.js` | root element, promote/demote in `onOpen`/`onClose`, native `close` listener |
| `styles.css`, `layouts/discovery.css`, `layouts/palette.css` | UA chrome resets, transparent `::backdrop` |

Visibility stays owned by the existing `mp-search-hidden` class; the new calls only add modality. Where `<dialog>` is unavailable (Safari before 15.4) they no-op, so those browsers behave exactly as before — which is also why the existing suite passes untouched.

Two resets are load-bearing rather than cosmetic: the palette and discovery roots draw their scrim with a child element and declare no background, so the UA's opaque `canvas` would have covered the page with a blank slab; and the palette root sizes purely from `inset: 0`, so the UA's `fit-content` would have collapsed it.

## Verification

A harness running the real `focus-trap` library, mirroring a theme's popup module (armed 100 ms after open, released only by the close button, Escape, or a page load), compared against a clean build of `main` on the same page with the same armed trap.

| | before | after |
| --- | --- | --- |
| root element | `DIV` | `DIALOG` |
| trap armed / nav open | yes / yes | yes / yes |
| input keeps focus | no | yes |
| typing `kaizen` lands | `""` | `"kaizen"` |
| focus ends on | the nav link | the search input |

The before column reproduces the reported symptom from the real click-and-type flow. Palette and discovery both report `:modal` with focus held and typing landing. Esc closes cleanly, with `isModalOpen` false, the scroll lock released and the hash cleared. 205 unit tests and lint pass.

## Note for review

Top-layer stacking belongs to the browser, so the overlay now sits above Ghost's subscribe button on desktop, where `z-index: 3999997` deliberately placed it below. Keeping that ordering would mean giving up `showModal()`, so it is one or the other. Flagging it as the one deliberate behaviour change here.

Unrelated and left alone: the discovery root overflows the viewport (1360×980 in 1280×900) because `.mp-search-discovery *` sets `box-sizing` on descendants but not the root, so its 40px padding adds to `width: 100%`. A build of `main` measures identically, so it predates this change.

## Summary by Sourcery

Use native modal dialogs for search surfaces to prevent theme focus traps from stealing focus when search opens without a page navigation.

Bug Fixes:
- Preserve search input focus when opening search from navigation controlled by a theme focus trap.
- Keep modal lifecycle state, scroll locking, and URL state synchronized when native dialog dismissal occurs.

Enhancements:
- Use native modal dialogs and the browser top layer for the search, palette, and discovery surfaces.
- Reset dialog user-agent styling and backdrops while retaining existing visibility and scrim behavior.
- Gracefully fall back to the existing non-modal behavior in browsers without dialog support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Search discovery and palette surfaces now use native modal behavior for better browser-level focus and layering.
  * Modal overlays maintain their existing appearance without browser-added borders, sizing constraints, or duplicate backdrops.
  * Dismissing a modal now consistently synchronizes its visibility, scrolling, and URL state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->