### PR TITLE
chore: release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-09-02
+
+### Fixed
+- **Opening the search from a theme's popup navigation left the panel visible
+  but unusable.** Readers could see the search but never type into it: the
+  input did not keep the caret. Loading `#/search` directly or using the
+  keyboard shortcut worked, which is what made it look like a search bug rather
+  than a focus one. Themes commonly focus-trap their popup navigation while it
+  is open, and a nav link pointing at Ghost's `#/search` magic URL changes the
+  hash without unloading the page — so none of the trap's release paths (close
+  button, Escape, page load) ever fire and the trap stays armed. Every surface
+  renders into the widget's shadow root in the same document, so the trap saw
+  the `focusin` and pulled the caret straight back into the navigation. Each
+  surface is now promoted into the top layer with `<dialog>.showModal()`: the
+  browser makes everything outside the top layer inert, so the trap's own
+  `focus()` call becomes a no-op and the caret stays in the search field. The
+  theme's accessibility code keeps working exactly as its author intended —
+  nothing patches or disables it. Visibility remains owned by the
+  `mp-search-hidden` class and the new calls no-op where `<dialog>` is
+  unavailable (Safari before 15.4), so those browsers behave as they did
+  before, and native `Esc` is routed back through the widget's own close path
+  so the scroll lock and the URL hash stay in step. One visible consequence:
+  top-layer stacking belongs to the browser, so the overlay now sits above
+  Ghost's subscribe button on desktop, where `z-index: 3999997` had placed it
+  below.
+
+### Changed
+- **Runtime dependency upgrades.** `@ts-ghost/content-api` 4.2.0 → 5.0.0 (core),
+  `@netlify/functions` 2.8.2 → 6.0.0 (webhook handler), and `ora` 8 → 9 (CLI).
+  Each is a major upgrade of a published package's dependency; none required a
+  source change, and lint, typecheck, the full suite and the builds pass
+  unchanged.
+- **The dev toolchain moved to Node 22.** `.nvmrc` pinned Node 20, which jsdom
+  30 does not support (`^22.22.2 || ^24.15.0 || >=26`) — its bundled undici
+  failed on load and took the search-ui suite down with it. Contributors and CI
+  now run Node 22. Nothing in the published packages changed, so this affects
+  only how the repository is built and tested.
+- **Test tooling refreshed**: vitest 1 → 4 (class mocks now have to be
+  constructible, so the mocked `TSGhostContentAPI`, Typesense `Client` and
+  `GhostTypesenseManager` return their instance from a `function`
+  implementation), jsdom 24 → 30, cssnano 6 → 9, rollup-plugin-visualizer 5 →
+  7, inquirer 12 → 14, globals 16 → 17, plus eslint, rollup, `@types/node` and
+  `@typescript-eslint/*` minors.
+
 ## [2.3.0] - 2026-08-21
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "CLI tool for managing Ghost content in Typesense",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.2.0",
-    "@magicpages/ghost-typesense-core": "^2.2.0",
+    "@magicpages/ghost-typesense-config": "^2.3.1",
+    "@magicpages/ghost-typesense-core": "^2.3.1",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "ora": "^9.4.1"

--- a/apps/webhook-handler/package.json
+++ b/apps/webhook-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-webhook",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Webhook handler for real-time Ghost content synchronization with Typesense",
   "author": "MagicPages",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.2.0",
-    "@magicpages/ghost-typesense-core": "^2.2.0",
+    "@magicpages/ghost-typesense-config": "^2.3.1",
+    "@magicpages/ghost-typesense-core": "^2.3.1",
     "@netlify/functions": "^6.0.0",
     "zod": "^4.4.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magicpages/ghost-typesense",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/cli": {
       "name": "@magicpages/ghost-typesense-cli",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.2.0",
-        "@magicpages/ghost-typesense-core": "^2.2.0",
+        "@magicpages/ghost-typesense-config": "^2.3.1",
+        "@magicpages/ghost-typesense-core": "^2.3.1",
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
         "ora": "^9.4.1"
@@ -86,11 +86,11 @@
     },
     "apps/webhook-handler": {
       "name": "@magicpages/ghost-typesense-webhook",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.2.0",
-        "@magicpages/ghost-typesense-core": "^2.2.0",
+        "@magicpages/ghost-typesense-config": "^2.3.1",
+        "@magicpages/ghost-typesense-core": "^2.3.1",
         "@netlify/functions": "^6.0.0",
         "zod": "^4.4.3"
       },
@@ -9074,7 +9074,7 @@
     },
     "packages/config": {
       "name": "@magicpages/ghost-typesense-config",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -9101,10 +9101,10 @@
     },
     "packages/core": {
       "name": "@magicpages/ghost-typesense-core",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@magicpages/ghost-typesense-config": "^2.2.0",
+        "@magicpages/ghost-typesense-config": "^2.3.1",
         "@ts-ghost/content-api": "5.0.0",
         "@ts-ghost/core-api": "^7.0.0",
         "typesense": "^1.7.2",
@@ -9128,7 +9128,7 @@
     },
     "packages/search-ui": {
       "name": "@magicpages/ghost-typesense-search-ui",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "typesense": "3.0.6"
@@ -9786,8 +9786,8 @@
     "@magicpages/ghost-typesense-cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.2.0",
-        "@magicpages/ghost-typesense-core": "^2.2.0",
+        "@magicpages/ghost-typesense-config": "^2.3.1",
+        "@magicpages/ghost-typesense-core": "^2.3.1",
         "@types/node": "^26.4.0",
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
@@ -9831,7 +9831,7 @@
     "@magicpages/ghost-typesense-core": {
       "version": "file:packages/core",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.2.0",
+        "@magicpages/ghost-typesense-config": "^2.3.1",
         "@ts-ghost/content-api": "5.0.0",
         "@ts-ghost/core-api": "^7.0.0",
         "@types/node": "^26.4.0",
@@ -9893,8 +9893,8 @@
     "@magicpages/ghost-typesense-webhook": {
       "version": "file:apps/webhook-handler",
       "requires": {
-        "@magicpages/ghost-typesense-config": "^2.2.0",
-        "@magicpages/ghost-typesense-core": "^2.2.0",
+        "@magicpages/ghost-typesense-config": "^2.3.1",
+        "@magicpages/ghost-typesense-core": "^2.3.1",
         "@netlify/functions": "^6.0.0",
         "@types/node": "^26.4.0",
         "rimraf": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-config",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Configuration types and utilities for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Core functionality for Ghost-Typesense integration",
   "author": "MagicPages",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@magicpages/ghost-typesense-config": "^2.2.0",
+    "@magicpages/ghost-typesense-config": "^2.3.1",
     "@ts-ghost/content-api": "5.0.0",
     "@ts-ghost/core-api": "^7.0.0",
     "typesense": "^1.7.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicpages/ghost-typesense-search-ui",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A vanilla JavaScript search UI for Ghost + Typesense integration",
   "type": "module",
   "main": "dist/search.min.js",


### PR DESCRIPTION
Cuts 2.3.1 across the five published packages.

## Contents

**Fixed** — opening the search from a theme's focus-trapped popup navigation left the panel visible but unusable (#93, merged in #94). Surfaces are promoted into the top layer with `<dialog>.showModal()`, so the trap's `focus()` call becomes a no-op.

**Runtime dependency majors** in published packages: `@ts-ghost/content-api` 4.2.0 → 5.0.0 (core), `@netlify/functions` 2.8.2 → 6.0.0 (webhook handler), `ora` 8 → 9 (CLI). None required a source change.

**Dev toolchain**: Node 22 (jsdom 30 does not support Node 20), vitest 1 → 4, jsdom 24 → 30, cssnano 6 → 9, rollup-plugin-visualizer 5 → 7, inquirer 12 → 14, globals 16 → 17.

Patch rather than minor: no public API or documented behaviour changed, matching the 2.2.1 precedent where a runtime dependency upgrade shipped as a patch.

## Changes

- `node scripts/bump-versions.js` → patch: all six manifests to 2.3.1. It also tightened the internal `@magicpages/*` ranges from the stale `^2.2.0` to `^2.3.1`, so a consumer can no longer resolve cli 2.3.1 against core 2.2.0.
- `CHANGELOG.md`: 2.3.1 entry.
- `package-lock.json`: version fields synced via `npm install`.

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (254 tests: config 18, core 23, webhook 5, cli 3, search-ui 205) and `npm run build` all pass locally on Node 22.

Merging this does not publish anything — publishing the `v2.3.1` GitHub Release does.

## Summary by Sourcery

Release version 2.3.1 with a fix for popup-navigation search focus and updated package dependencies.

Bug Fixes:
- Fix search panels opened from theme popup navigation so they remain focusable and usable.

Enhancements:
- Upgrade published runtime dependencies and refresh the development and test toolchain for Node 22.
- Keep internal package dependency ranges aligned with the 2.3.1 release.

Build:
- Bump all published packages and workspace manifests to version 2.3.1 and synchronize the lockfile.

Documentation:
- Add the 2.3.1 changelog entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed search focus behavior in the theme popup, making it easier to begin typing immediately.

- **Chores**
  - Updated the application and package versions to 2.3.1.
  - Refreshed runtime, development, testing, and build dependencies.
  - Migrated development tooling to Node.js 22.

- **Documentation**
  - Added release information for version 2.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->